### PR TITLE
state-check: fix test-modification false-positives + add placeholder/ambiguity checks

### DIFF
--- a/state-check/scripts/state-check.py
+++ b/state-check/scripts/state-check.py
@@ -31,6 +31,29 @@ from typing import Optional
 
 
 # =====================================================================
+# Module-level patterns
+# =====================================================================
+
+# Path components that unambiguously denote test code.
+TEST_PATH_COMPONENTS = {"tests", "test", "__tests__", "spec", "specs"}
+
+# Filename forms: foo_test.py, test_foo.py, foo.test.ts, foo.spec.tsx, etc.
+TEST_FILENAME_RE = re.compile(
+    r"(^|[._-])(test|spec)([._-]|$)|\.(test|spec)\.[A-Za-z0-9]+$",
+    re.IGNORECASE,
+)
+
+# CLAUDE.md unfilled placeholders, e.g. <PROJECT_NAME>, <CLIENT NAME>.
+PLACEHOLDER_RE = re.compile(r"<[A-Z][A-Z0-9 _-]{2,}>")
+
+# Status: line in a failures-log entry.
+FAILURE_STATUS_RE = re.compile(
+    r"^\s*Status:\s*(?P<status>.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+# =====================================================================
 # Data classes
 # =====================================================================
 
@@ -142,21 +165,23 @@ def count_tasks(tasks_file: Path) -> tuple[int, int, int]:
     return (open_count, complete_count, deferred_count)
 
 
-def find_active_initiative(repo: Path) -> Optional[str]:
-    """Find the most recently modified design doc under docs/, excluding known subfolders."""
+def find_active_initiative(repo: Path) -> tuple[Optional[str], list[Path]]:
+    """Find the most recently modified design doc under docs/.
+
+    Returns (active_stem, all_candidates). The candidate list lets callers
+    detect ambiguity when multiple design docs compete for "active".
+    """
     docs_dir = repo / "docs"
     if not docs_dir.is_dir():
-        return None
-    excluded_dirs = {"intake", "contract", "decisions", "failures", "client-facing"}
+        return (None, [])
     candidates = [
         p for p in docs_dir.iterdir()
         if p.is_file() and p.suffix == ".md" and p.stem != "hypothesis"
     ]
     if not candidates:
-        return None
-    # Use most recently modified as a heuristic for "active"
+        return (None, [])
     latest = max(candidates, key=lambda p: p.stat().st_mtime)
-    return latest.stem
+    return (latest.stem, candidates)
 
 
 # =====================================================================
@@ -177,23 +202,61 @@ def git_file_exists_in_history(repo: Path, path: str) -> bool:
         return False
 
 
-def git_recent_test_modifications(repo: Path, since: str = "2.days") -> list[str]:
+def is_test_file(path: str) -> bool:
+    """Path-component / filename match for test files.
+
+    Avoids substring false positives like 'latest.md', 'contest_routes.py',
+    'src/spectrum.py'.
     """
-    Return list of test files modified in recent commits. A heuristic for the
-    "tests modified to match code" anti-pattern. Empty list on error.
+    parts = path.replace("\\", "/").split("/")
+    if any(part.lower() in TEST_PATH_COMPONENTS for part in parts):
+        return True
+    name = parts[-1] if parts else path
+    return bool(TEST_FILENAME_RE.search(name))
+
+
+def find_latest_lock_commit(repo: Path) -> Optional[str]:
+    """Return the SHA of the most recent commit that added/touched a sprint .lock.
+
+    Returns None if no lock has been committed or git is unavailable.
     """
     try:
         result = subprocess.run(
-            ["git", "-C", str(repo), "log", f"--since={since}", "--name-only", "--pretty=format:"],
+            ["git", "-C", str(repo), "log", "-1", "--format=%H", "--",
+             ":(glob)sprints/*/.lock"],
             capture_output=True,
             text=True,
             timeout=5,
         )
         if result.returncode != 0:
+            return None
+        sha = result.stdout.strip()
+        return sha or None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
+def git_recent_test_modifications(repo: Path) -> list[str]:
+    """Return test files modified since the most recent sprint .lock.
+
+    Falls back to a 14-day window if no .lock has been committed yet — this
+    widens the previous brittle 2-day window so weekend/vacation gaps don't
+    silently dodge the check.
+    Empty list on error.
+    """
+    base = find_latest_lock_commit(repo)
+    cmd = ["git", "-C", str(repo), "log"]
+    if base:
+        cmd.append(f"{base}..HEAD")
+    else:
+        cmd.append("--since=14.days")
+    cmd.extend(["--name-only", "--pretty=format:"])
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        if result.returncode != 0:
             return []
         lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
-        # Heuristic: any file with "test" in the path
-        return sorted(set(l for l in lines if "test" in l.lower()))
+        return sorted(set(l for l in lines if is_test_file(l)))
     except (subprocess.SubprocessError, FileNotFoundError):
         return []
 
@@ -225,20 +288,87 @@ def check_claude_md_size(repo: Path) -> Optional[Flag]:
     return None
 
 
+def check_claude_md_placeholders(repo: Path) -> Optional[Flag]:
+    """Detect unfilled <BRACKETED> placeholders in CLAUDE.md.
+
+    A CLAUDE.md that exists with placeholders is worse than missing — every
+    session reads placeholder context as if it were real instructions.
+    """
+    claude_md = repo / "CLAUDE.md"
+    if not claude_md.is_file():
+        return None  # missing-file case is handled by check_claude_md_size
+    try:
+        text = claude_md.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    matches = sorted(set(PLACEHOLDER_RE.findall(text)))
+    if not matches:
+        return None
+    sample = ", ".join(matches[:3])
+    more = "" if len(matches) <= 3 else f" (+{len(matches) - 3} more)"
+    return Flag(
+        severity="P0",
+        category="setup",
+        message=f"CLAUDE.md contains unfilled placeholders: {sample}{more}",
+        suggested_action="Replace each <BRACKETED> placeholder with project-specific content. Unfilled placeholders read like real instructions to the LLM.",
+    )
+
+
 def check_failures_log_size(repo: Path) -> Optional[Flag]:
+    """Count *active* prevention rules — not files.
+
+    Entries with `Status: Retired` (or similar) don't count against the 20–50
+    guideline. Entries lacking a Status: line are counted as active and called
+    out so the team can annotate them.
+    """
     failures_dir = repo / "docs" / "failures"
     if not failures_dir.is_dir():
         return None
-    entries = [p for p in failures_dir.iterdir() if p.is_file() and p.suffix == ".md" and p.stem not in ("README", "TEMPLATE")]
-    count = len(entries)
-    if count > 100:
+    entries = [
+        p for p in failures_dir.iterdir()
+        if p.is_file() and p.suffix == ".md" and p.stem not in ("README", "TEMPLATE")
+    ]
+    active = 0
+    unannotated = 0
+    for p in entries:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        m = FAILURE_STATUS_RE.search(text)
+        if m is None:
+            unannotated += 1
+            active += 1  # treat as active until proven otherwise
+            continue
+        status = m.group("status").lower()
+        if "active" in status:
+            active += 1
+    if active > 50:
+        msg = f"Failures log has {active} active prevention rule(s) (guideline: 20–50)."
+        if unannotated:
+            msg += f" {unannotated} entr(ies) lack a Status: line and were counted as active."
         return Flag(
             severity="P2",
             category="memory",
-            message=f"Failures log has {count} entries (guideline: prune beyond 20–50 active rules).",
-            suggested_action="Run a consolidation pass: merge entries producing the same prevention rule; retire rules unused in 12 months.",
+            message=msg,
+            suggested_action="Consolidate duplicate rules; mark obsolete entries `Status: Retired`. Add a Status: line to any unannotated entries.",
         )
     return None
+
+
+def check_multiple_initiatives(candidates: list) -> Optional[Flag]:
+    """Warn when multiple design docs compete for the active-initiative slot."""
+    if len(candidates) <= 1:
+        return None
+    names = sorted(p.stem for p in candidates)
+    sample = ", ".join(names[:3])
+    more = "" if len(names) <= 3 else f" (+{len(names) - 3} more)"
+    return Flag(
+        severity="P1",
+        category="ambiguity",
+        message=f"Multiple design docs found under docs/: {sample}{more}. Active initiative was picked by mtime — may be wrong.",
+        suggested_action="Move inactive design docs under docs/archive/ or pick an explicit convention (e.g., frontmatter `status: active`).",
+    )
 
 
 def check_sprint_state(sprint: Path, mode: str) -> list[Flag]:
@@ -454,13 +584,23 @@ def run_state_check(repo: Path) -> ModeState:
         state.phase = "between-sprints"
         state.active_sprint = str(sprint_dirs[-1].relative_to(repo)) + " (locked)"
 
-    state.active_initiative = find_active_initiative(repo)
+    active_init, init_candidates = find_active_initiative(repo)
+    state.active_initiative = active_init
 
     # Repo-wide checks
-    for check in (check_claude_md_size, check_failures_log_size, check_test_modifications):
+    for check in (
+        check_claude_md_size,
+        check_claude_md_placeholders,
+        check_failures_log_size,
+        check_test_modifications,
+    ):
         flag = check(repo)
         if flag:
             state.flags.append(flag)
+
+    multi = check_multiple_initiatives(init_candidates)
+    if multi:
+        state.flags.append(multi)
 
     state.flags.extend(check_mode_specific(mode, stage, repo))
 

--- a/state-check/tests/test_state_check.py
+++ b/state-check/tests/test_state_check.py
@@ -1,0 +1,195 @@
+"""Self-tests for state-check.py.
+
+Exercises each code path added or refactored for issue #1:
+  - is_test_file (path-component match, no substring false positives)
+  - find_active_initiative (tuple return)
+  - check_multiple_initiatives (ambiguity warning)
+  - check_claude_md_placeholders (P0 on unfilled <BRACKETED> markers)
+  - check_failures_log_size (counts active rules, not files)
+  - find_latest_lock_commit / git_recent_test_modifications (graceful no-git)
+
+Run with:  python -m unittest state-check/tests/test_state_check.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_state_check():
+    """Load state-check.py despite the hyphen in its filename.
+
+    The module must be registered in sys.modules *before* exec_module so that
+    dataclass annotation resolution can find it (required on Python 3.8).
+    """
+    here = Path(__file__).resolve().parent
+    script = here.parent / "scripts" / "state-check.py"
+    spec = importlib.util.spec_from_file_location("state_check", script)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["state_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = _load_state_check()
+
+
+class IsTestFileTests(unittest.TestCase):
+    def test_path_components_match(self):
+        for path in [
+            "tests/foo.py",
+            "src/__tests__/Component.test.tsx",
+            "spec/widget_spec.rb",
+            "app/test/whatever.go",
+        ]:
+            self.assertTrue(sc.is_test_file(path), path)
+
+    def test_filename_patterns_match(self):
+        for path in [
+            "src/foo_test.py",
+            "src/test_foo.py",
+            "src/Foo.test.ts",
+            "src/Foo.spec.tsx",
+        ]:
+            self.assertTrue(sc.is_test_file(path), path)
+
+    def test_substring_false_positives_rejected(self):
+        for path in [
+            "docs/latest.md",
+            "src/contest_routes.py",
+            "src/spectrum.py",
+            "lib/protest.go",
+        ]:
+            self.assertFalse(sc.is_test_file(path), path)
+
+
+class FindActiveInitiativeTests(unittest.TestCase):
+    def test_returns_tuple_no_docs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            active, candidates = sc.find_active_initiative(Path(tmp))
+            self.assertIsNone(active)
+            self.assertEqual(candidates, [])
+
+    def test_picks_latest_and_returns_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs"
+            docs.mkdir()
+            (docs / "alpha.md").write_text("a", encoding="utf-8")
+            beta = docs / "beta.md"
+            beta.write_text("b", encoding="utf-8")
+            # Bump beta's mtime slightly
+            import os, time
+            future = time.time() + 60
+            os.utime(beta, (future, future))
+            active, candidates = sc.find_active_initiative(Path(tmp))
+            self.assertEqual(active, "beta")
+            self.assertEqual(len(candidates), 2)
+
+
+class MultipleInitiativesTests(unittest.TestCase):
+    def test_no_warning_on_single(self):
+        self.assertIsNone(sc.check_multiple_initiatives([Path("docs/only.md")]))
+
+    def test_warning_on_multiple(self):
+        flag = sc.check_multiple_initiatives(
+            [Path("docs/alpha.md"), Path("docs/beta.md")]
+        )
+        self.assertIsNotNone(flag)
+        self.assertEqual(flag.severity, "P1")
+        self.assertIn("alpha", flag.message)
+        self.assertIn("beta", flag.message)
+
+
+class ClaudeMdPlaceholderTests(unittest.TestCase):
+    def test_no_file_no_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(sc.check_claude_md_placeholders(Path(tmp)))
+
+    def test_clean_file_no_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CLAUDE.md").write_text(
+                "# Project\nSome real content here.\n", encoding="utf-8"
+            )
+            self.assertIsNone(sc.check_claude_md_placeholders(Path(tmp)))
+
+    def test_placeholders_flagged_p0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CLAUDE.md").write_text(
+                "Project: <PROJECT_NAME>\nClient: <CLIENT NAME>\n",
+                encoding="utf-8",
+            )
+            flag = sc.check_claude_md_placeholders(Path(tmp))
+            self.assertIsNotNone(flag)
+            self.assertEqual(flag.severity, "P0")
+            self.assertIn("PROJECT_NAME", flag.message)
+
+    def test_short_brackets_ignored(self):
+        # <A> and <B> shouldn't trigger — they're below the length threshold.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CLAUDE.md").write_text(
+                "Use <A> and <B> in formulas.", encoding="utf-8"
+            )
+            self.assertIsNone(sc.check_claude_md_placeholders(Path(tmp)))
+
+
+class FailuresLogTests(unittest.TestCase):
+    def _make_entry(self, dir: Path, name: str, status: str | None) -> None:
+        body = f"# {name}\n\n"
+        if status is not None:
+            body += f"Status: {status}\n"
+        body += "Body text.\n"
+        (dir / f"{name}.md").write_text(body, encoding="utf-8")
+
+    def test_no_dir_no_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(sc.check_failures_log_size(Path(tmp)))
+
+    def test_retired_entries_dont_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp) / "docs" / "failures"
+            d.mkdir(parents=True)
+            for i in range(60):
+                self._make_entry(d, f"rule-{i:03d}", "Retired")
+            for i in range(5):
+                self._make_entry(d, f"active-{i:03d}", "Active prevention rule")
+            # 60 retired + 5 active = 65 files but only 5 active → no flag
+            self.assertIsNone(sc.check_failures_log_size(Path(tmp)))
+
+    def test_active_threshold_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp) / "docs" / "failures"
+            d.mkdir(parents=True)
+            for i in range(55):
+                self._make_entry(d, f"rule-{i:03d}", "Active prevention rule")
+            flag = sc.check_failures_log_size(Path(tmp))
+            self.assertIsNotNone(flag)
+            self.assertEqual(flag.severity, "P2")
+            self.assertIn("55", flag.message)
+
+    def test_unannotated_counted_as_active_and_called_out(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp) / "docs" / "failures"
+            d.mkdir(parents=True)
+            for i in range(51):
+                self._make_entry(d, f"rule-{i:03d}", None)
+            flag = sc.check_failures_log_size(Path(tmp))
+            self.assertIsNotNone(flag)
+            self.assertIn("lack a Status:", flag.message)
+
+
+class GitGracefulFallbackTests(unittest.TestCase):
+    """find_latest_lock_commit and git_recent_test_modifications must not
+    raise on non-git directories."""
+
+    def test_non_git_returns_none_and_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(sc.find_latest_lock_commit(Path(tmp)))
+            self.assertEqual(sc.git_recent_test_modifications(Path(tmp)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1. Six behavior changes to `state-check/scripts/state-check.py`, each covered by a new self-test fixture.

- **Path-component test-file match.** `is_test_file()` replaces the substring `"test"` heuristic — no more false positives on `latest.md`, `spectrum.py`, `contest_routes.py`. Positive matches via path component (`/tests/`, `/__tests__/`, `/spec/`) or filename pattern (`_test.py`, `.test.ts`, `.spec.tsx`).
- **Wider detection window.** `find_latest_lock_commit()` locates the most recent sprint `.lock` commit; `git_recent_test_modifications()` reads from there to HEAD. 14-day window fallback for repos pre-first-lock. Removes the weekend/vacation brittleness of the 2-day cutoff.
- **CLAUDE.md placeholder check (new, P0).** `check_claude_md_placeholders()` flags unfilled `<BRACKETED>` markers. An existing-but-unfilled CLAUDE.md is worse than a missing one — every session reads the placeholder text as real instructions.
- **Failures log counts active rules.** `check_failures_log_size()` parses `Status:` lines. Retired entries don't count against the 20–50 guideline; unannotated entries count as active and are called out in the message.
- **Multi-initiative ambiguity warning (P1).** `find_active_initiative()` now returns `(active_stem, candidates)`. When multiple design docs exist, `check_multiple_initiatives()` flags that the active pick was made by mtime and suggests moving inactive docs to `docs/archive/`.
- **Self-test fixture.** `state-check/tests/test_state_check.py` — 16 tests covering each new code path, substring-false-positive cases, active/retired/unannotated failures-log mixing, and non-git graceful fallback. Loads the hyphenated script via `importlib.util` (registers in `sys.modules` before `exec_module` for Python 3.8 dataclass compatibility).

## Test plan

- [x] `python3 state-check/tests/test_state_check.py -v` — 16/16 passing
- [x] `python3 state-check/scripts/state-check.py --json` on this repo still emits coherent output
- [ ] Reviewer spot-checks `is_test_file()` against a repo with `__tests__/` dirs and non-test files containing `"test"` as a substring

## Acceptance checklist (from #1)

- [x] Test-modification check uses path-component match
- [x] Window for test-modification check widened (to last `.lock`, 14d fallback)
- [x] CLAUDE.md placeholder check added (P0)
- [x] Failures-log count parses `Status:`
- [x] Multi-design-doc ambiguity warning
- [x] Existing CLI behavior unchanged for true-positive cases
- [x] Self-test fixture added under `state-check/tests/`

Generated with [Claude Code](https://claude.com/claude-code)
