### PR TITLE
docs: AI-assisted PR review checklist + handbook + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- 1-3 bullet points on what this PR changes and why. -->
+
+## Requirements addressed
+
+<!-- List the stable IDs this PR satisfies: §X.Y, Dn, Qn, SOW-§X.Y. Must match the Satisfies: lines in TASKS.md. -->
+
+- Satisfies:
+
+## Test plan
+
+<!-- Bulleted checklist of what was exercised, including test-matrix categories (A-E) where relevant. -->
+
+- [ ]
+
+## AI assistance
+
+- **AI-assisted:** yes / no
+
+<!--
+If yes, complete the AI-assisted PR review checklist before approval:
+  tooling/templates/code-review-AI-CHECKLIST.md
+
+A reviewer who approves an AI-assisted PR without completing the checklist owns the regressions.
+-->
+
+## Anything reviewers should know
+
+<!-- Deferred tasks, known limitations, follow-up issues. Leave empty if none. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Prioritized roadmap — items listed in rough order of leverage-per-effort.
 - **Gate ceremony skills** — `/gate-1-to-2`, `/gate-2-to-3` for Internal Product Mode graduation gates, reusing the interview protocol from the state-check skill.
 - **Tightened Gate 2 criteria in Internal Product Mode** — add a concrete retention metric (e.g., N-week self-directed return rate) to prevent graduation on optimism.
 - **Resolve the Stage 1 test-matrix contradiction** — Internal Product Mode lists Category D as "only if time permits" in the table but treats it as required in the anti-patterns section. Reconcile.
+- **AI code-smell review checklist** ([#5](https://github.com/colaberry/ai-assisted-development-method/issues/5)) — handbook chapter + `tooling/templates/code-review-AI-CHECKLIST.md` targeting AI-specific PR review failure modes (surface correctness, invented APIs, silent scope creep). Pure-doc change; land first.
+- **`/incident` skill** ([#6](https://github.com/colaberry/ai-assisted-development-method/issues/6)) — post-deployment learning loop. Writes a post-mortem, extracts prevention rules into `docs/failures/`, optionally drafts a design-doc update PR when an incident invalidates a requirement. Completes the SDLC coverage that today stops at sprint close.
+- **Semgrep security merge gate** ([#7](https://github.com/colaberry/ai-assisted-development-method/issues/7)) — `tooling/.github/workflows/security.yml` alongside `reconcile.yml`. Traceability + security become the two structural gates; manual `/security-review` becomes the escalation path, not the only layer.
+- **`Autonomy:` annotation in TASKS.md** ([#8](https://github.com/colaberry/ai-assisted-development-method/issues/8)) — optional per-task line (`direct` | `checkpoint` | `review-only`) that tunes how often `/dev` pauses for human confirmation. Ties autonomy to task risk and test coverage.
 
 ## [3.2.1] — 2026-04-16
 

--- a/handbook/Developer_Handbook.md
+++ b/handbook/Developer_Handbook.md
@@ -159,6 +159,26 @@ Read it on your first day. Read it when you join a new client repo. Read it befo
 
 If CLAUDE.md is over 500 lines or clearly stale, that's a problem to raise — don't just work around it. Stale context is worse than no context because it misleads confidently.
 
+### 1.8 Reviewing AI-assisted PRs
+
+AI-generated code has a distinct smell. It looks correct — often more polished than hand-written code — but it fails in specific, repeatable ways that generic PR review doesn't catch: invented APIs that don't exist in the pinned version, over-defensive guards against impossible states, plausible-but-wrong docstrings, silent scope creep beyond the task's `Satisfies:` IDs, and tests that were adjusted to match the implementation instead of describing the behavior.
+
+Generic review training tells you to look for "bugs" and "readability." Neither framework surfaces these patterns. The review needs to be AI-aware.
+
+**The rule:** on any PR marked `AI-assisted: yes`, complete the [AI-assisted PR review checklist](../tooling/templates/code-review-AI-CHECKLIST.md) before approving. Copy the checklist into the PR description or reference it with `✅ AI-assist review: checklist-v1 completed by @<reviewer>`.
+
+**What the checklist adds over generic review:**
+
+- Scope verification against `Satisfies:` IDs — catches when the agent "cleaned up adjacent code" without being asked.
+- API existence checks — catches hallucinated method signatures, config keys, CLI flags, env variables. Grep vendor docs; don't trust the snippet.
+- Plausible-but-wrong docstring detection — read the docstring and function body independently; if the docstring could describe any function in this codebase, it's hallucinated.
+- Defensive-coding detection — flags `null` checks on parameters that can't be null, `except: pass` blocks, swallowed promise rejections.
+- Test-modification scrutiny — if a test changed in the diff, the commit message must explain *why the old assertion was wrong*. "Adjusted test to match new behavior" is a red flag, not an explanation.
+
+Items marked `[blocking]` in the checklist are merge-blockers; don't approve with caveats. Walk the list top to bottom — the whole point is to force the pause.
+
+**When to skip the checklist.** When the diff was genuinely written by a human and the agent was only used for tab-completion or formatting, `AI-assisted: no` is honest. Don't checkbox-ritualize the process; either the checklist earns its time or it doesn't.
+
 ---
 
 ## Part 2: Prompting Claude Code within the method
@@ -357,6 +377,7 @@ If the method feels slow after five initiatives, look for these specific problem
 3. Check for test modifications in the diff. If tests were changed to match code, that's a flag.
 4. Check CLAUDE.md compliance. Any never-do rules violated?
 5. Check for unrequested scope. If the code does things tests don't require, that's a flag.
+6. If the PR is marked `AI-assisted: yes`, walk the [AI-assisted PR review checklist](../tooling/templates/code-review-AI-CHECKLIST.md) top to bottom.
 
 ### When something goes wrong
 

--- a/tooling/templates/code-review-AI-CHECKLIST.md
+++ b/tooling/templates/code-review-AI-CHECKLIST.md
@@ -1,0 +1,65 @@
+# AI-Assisted PR Review Checklist
+
+Use this checklist on any PR where a coding agent (Claude Code, Copilot, Cursor, etc.) produced a material share of the diff. It targets failure modes that pattern-match as "AI code smell" — issues a human would usually catch but that pass review because the output *looks* correct.
+
+**How to use it:**
+
+1. Copy the checklist into the PR description (or reference it with "✅ AI-assist review: checklist-v1 completed by @reviewer").
+2. Walk items top-to-bottom. Check each one or leave a note explaining why it doesn't apply.
+3. If any item is a red flag, request changes — do **not** approve with caveats. The whole point of the checklist is to force the pause.
+4. Items marked **[blocking]** are merge-blockers when they fail. Other items are strongly-worded defaults you may override with written justification.
+
+---
+
+## 1. Scope
+
+- [ ] **[blocking] Diff matches the task's `Satisfies:` IDs.** No files changed outside what the IDs would require. If the diff touches code adjacent to the requirement "because it was messy," that's scope creep — either expand the task, open a new one, or revert the drift.
+- [ ] **[blocking] No silent `[DEFERRED]` tasks.** Any task that wasn't finished is either complete (checked off), explicitly deferred in TASKS.md with a follow-up issue link, or visible in the PR description as "not done."
+- [ ] **No dead code in the diff.** If a function, import, variable, or branch is added but never reached, delete it. Agents frequently hedge with unused helpers; the deletion is on you.
+
+## 2. Correctness
+
+- [ ] **Edge cases, not just the golden path.** Empty input, single-element input, duplicate input, `None`/`null`/`undefined`, unicode, timezone boundaries, off-by-one on loops, integer overflow where the language allows it. Tests exist for at least the ones that apply.
+- [ ] **[blocking] Tests weren't modified to match the code.** If a test changed in this PR, the commit message explains *why the old assertion was wrong*. Use `state-check.py` to surface recently-modified test files if unsure.
+- [ ] **[blocking] No invented APIs.** Every imported symbol, library method, CLI flag, config key, env variable, and type signature actually exists in the version pinned in lockfile/pyproject/package.json. Grep the vendor docs or `go doc` / `python -c 'import x; help(x.y)'` if you're not sure.
+- [ ] **Concurrency claims are earned.** If the diff calls something "thread-safe," "atomic," "idempotent," or "race-free," there is either a test demonstrating it or a line of prose explaining the invariant that makes it true.
+
+## 3. Error handling
+
+- [ ] **No defensive coding for impossible states.** If a caller can only pass a non-null value (type system, framework guarantee, upstream validation), the function should not check for null. Agents love to add belt-and-suspenders guards that obscure real bugs.
+- [ ] **Failures fail loudly.** `except: pass`, `catch { }`, swallowed promise rejections, ignored return codes — flag every one. If the error is genuinely ignorable, the code says *why* in one line.
+- [ ] **Error messages name what failed, not what was attempted.** `"failed to parse config at line 42: unexpected indent"` beats `"error loading config"`.
+
+## 4. Comments and documentation
+
+- [ ] **Comments describe *why*, not *what*.** Any comment that re-narrates the next line of code should be deleted. Agents over-comment; leave the non-obvious invariant and cut the rest.
+- [ ] **No comments that reference the agent or this task.** `# Added per user request`, `# Handles the case Claude identified`, `# Fix for the bug in the prompt` — all of these rot within a week. If the insight is load-bearing, put it in a commit message or design doc.
+- [ ] **No plausible-but-wrong docstrings.** Read the docstring and the function body independently. If the docstring could plausibly describe any function in this codebase, it's probably hallucinated. Rewrite it to describe *this* function.
+
+## 5. Security
+
+- [ ] **User input never reaches a shell, SQL query, HTML body, template, or eval-like construct unescaped.** Parameterized queries, templating engines with autoescape, `shlex.quote`, framework-provided sanitizers — one of these is in the path.
+- [ ] **No hardcoded secrets, keys, tokens, or credentials.** Not even in tests, not even in comments, not even "temporarily."
+- [ ] **No new outbound network calls the agent added on its own initiative.** Every `requests.get`, `fetch`, `subprocess` that wasn't in the task description gets explicit justification.
+
+## 6. Tests
+
+- [ ] **New behavior has new tests.** Not "the build passes" — actual test function(s) asserting the behavior introduced by the diff.
+- [ ] **Test names describe the behavior under test, not the implementation.** `test_returns_empty_list_when_input_is_empty` beats `test_parse_function_branch_3`.
+- [ ] **At least one test in categories D (adversarial/security) or E (property/mutation) for any code on a trust boundary or arithmetic hot path.** See the method's test matrix.
+- [ ] **No `@skip`, `xfail`, or `.only()` left in the diff** unless the skip has a follow-up issue linked in the comment.
+
+## 7. Fit with existing code
+
+- [ ] **Style matches the file, not the agent's defaults.** Indent, quote style, import ordering, naming conventions. If the surrounding file uses `snake_case` and the agent produced `camelCase`, fix it — don't let the codebase fork.
+- [ ] **No duplicated helpers.** If the agent reimplemented `debounce`, `uniq`, `chunk`, a retry wrapper, or a timestamp-formatter that already exists in the repo, use the existing one. Grep before accepting.
+- [ ] **No premature abstractions.** One caller ≠ generic helper. Three similar lines are fine; a `BaseGenericFactoryProvider<T>` for a two-call use case is not.
+
+## 8. Commit hygiene
+
+- [ ] **Commit messages explain intent.** "Add auth middleware" is worse than "Add auth middleware to satisfy SOW-§3.2 — blocks unauthenticated /admin/* access, returns 401 with Retry-After on rate limit."
+- [ ] **No commits with "claude" / "copilot" / agent-branded messages** that leak into the shared history. Re-author or squash before merge; the tool is an implementation detail.
+
+---
+
+**Origin.** This checklist is maintained at [tooling/templates/code-review-AI-CHECKLIST.md](.). Propose additions via PR with a concrete failure-mode example — items not tied to a real failure get cut in the next pruning pass.


### PR DESCRIPTION
## Summary

Closes #5. Pure-doc change — no tooling, no schema change.

- **Checklist** at `tooling/templates/code-review-AI-CHECKLIST.md` — ~25 items organized across scope, correctness, error handling, comments, security, tests, fit, and commit hygiene. Items marked `[blocking]` block merge; others are strongly-worded defaults.
- **Handbook §1.8 "Reviewing AI-assisted PRs"** — explains why generic PR review misses AI-specific failure modes and when the checklist applies vs. when to skip it honestly.
- **Part 4 quick-reference** updated to link the full checklist.
- **`.github/pull_request_template.md`** adds a `Satisfies:` reminder, test plan, and `AI-assisted: yes/no` field that points reviewers at the checklist.
- **CHANGELOG Unreleased** extended with issues #5–#8 cross-links.

## Notes for reviewers

- The checklist deliberately overlaps a bit with the existing Part 4 quick-reference. The quick-ref is a 5-item memory aid; the full checklist is the artifact you attach to the PR. Both stay.
- Acceptance criterion #4 ("at least 3 items cite a specific failure from this project's failures log") is not yet met — this repo has no `docs/failures/` entries. Items will get grounded once we accumulate real failures. Tracking as a follow-up, not a blocker.

## Test plan

- [x] Checklist renders cleanly in GitHub preview
- [x] PR template takes effect on this PR (you're reading it right now)
- [ ] Reviewer spot-checks for items that are too verbose or too vague — prune before merge

## Acceptance from #5

- [x] Checklist template committed
- [x] Handbook chapter added + linked
- [x] PR template references the checklist
- [ ] 3 items cite specific project failures (deferred until failures log has entries)

Generated with [Claude Code](https://claude.com/claude-code)
