### PR TITLE
docs: introduce AADM acronym + .claude/settings.json for team acceptEdits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- 1-3 bullet points on what this PR changes and why. -->
+
+## Requirements addressed
+
+<!-- List the stable IDs this PR satisfies: §X.Y, Dn, Qn, SOW-§X.Y. Must match the Satisfies: lines in TASKS.md. -->
+
+- Satisfies:
+
+## Test plan
+
+<!-- Bulleted checklist of what was exercised, including test-matrix categories (A-E) where relevant. -->
+
+- [ ]
+
+## AI assistance
+
+- **AI-assisted:** yes / no
+
+<!--
+If yes, complete the AI-assisted PR review checklist before approval:
+  tooling/templates/code-review-AI-CHECKLIST.md
+
+A reviewer who approves an AI-assisted PR without completing the checklist owns the regressions.
+-->
+
+## Anything reviewers should know
+
+<!-- Deferred tasks, known limitations, follow-up issues. Leave empty if none. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Prioritized roadmap — items listed in rough order of leverage-per-effort.
 - **Gate ceremony skills** — `/gate-1-to-2`, `/gate-2-to-3` for Internal Product Mode graduation gates, reusing the interview protocol from the state-check skill.
 - **Tightened Gate 2 criteria in Internal Product Mode** — add a concrete retention metric (e.g., N-week self-directed return rate) to prevent graduation on optimism.
 - **Resolve the Stage 1 test-matrix contradiction** — Internal Product Mode lists Category D as "only if time permits" in the table but treats it as required in the anti-patterns section. Reconcile.
+- **AI code-smell review checklist** ([#5](https://github.com/colaberry/ai-assisted-development-method/issues/5)) — handbook chapter + `tooling/templates/code-review-AI-CHECKLIST.md` targeting AI-specific PR review failure modes (surface correctness, invented APIs, silent scope creep). Pure-doc change; land first.
+- **`/incident` skill** ([#6](https://github.com/colaberry/ai-assisted-development-method/issues/6)) — post-deployment learning loop. Writes a post-mortem, extracts prevention rules into `docs/failures/`, optionally drafts a design-doc update PR when an incident invalidates a requirement. Completes the SDLC coverage that today stops at sprint close.
+- **Semgrep security merge gate** ([#7](https://github.com/colaberry/ai-assisted-development-method/issues/7)) — `tooling/.github/workflows/security.yml` alongside `reconcile.yml`. Traceability + security become the two structural gates; manual `/security-review` becomes the escalation path, not the only layer.
+- **`Autonomy:` annotation in TASKS.md** ([#8](https://github.com/colaberry/ai-assisted-development-method/issues/8)) — optional per-task line (`direct` | `checkpoint` | `review-only`) that tunes how often `/dev` pauses for human confirmation. Ties autonomy to task risk and test coverage.
 
 ## [3.2.1] — 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AI-Assisted Development Method
+# AI-Assisted Development Method (AADM)
 
-A structured process for shipping enterprise-grade software with Claude Code. Designed for small teams (3–10 engineers) delivering to external clients, with a companion mode for internal product development that may eventually ship as SaaS.
+**AADM** is a structured process for shipping enterprise-grade software with Claude Code. Designed for small teams (3–10 engineers) delivering to external clients, with a companion mode for internal product development that may eventually ship as SaaS.
 
 **Current versions:** Method v3.2.1 · Internal Product Mode v1.0 · state-check v0.1
 

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,6 +1,6 @@
-# AI-Assisted Development Method — Final Bundle (v3.2.1)
+# AI-Assisted Development Method (AADM) — Final Bundle (v3.2.1)
 
-This bundle contains everything needed to adopt the AI-Assisted Development Method on a new or existing client repo. Read this file first, then follow the "Getting Started" steps below.
+This bundle contains everything needed to adopt AADM on a new or existing client repo. Read this file first, then follow the "Getting Started" steps below.
 
 ## What's in this bundle
 

--- a/handbook/Developer_Handbook.md
+++ b/handbook/Developer_Handbook.md
@@ -1,6 +1,6 @@
 # Developer Handbook
 
-*Practices for engineers working on teams that use the AI-Assisted Development Method*
+*Practices for engineers working on teams that use the AI-Assisted Development Method (AADM)*
 
 This document is for engineers on the ground. It assumes you have read (or will read) the main method document. This handbook covers three things:
 

--- a/handbook/Developer_Handbook.md
+++ b/handbook/Developer_Handbook.md
@@ -159,6 +159,26 @@ Read it on your first day. Read it when you join a new client repo. Read it befo
 
 If CLAUDE.md is over 500 lines or clearly stale, that's a problem to raise — don't just work around it. Stale context is worse than no context because it misleads confidently.
 
+### 1.8 Reviewing AI-assisted PRs
+
+AI-generated code has a distinct smell. It looks correct — often more polished than hand-written code — but it fails in specific, repeatable ways that generic PR review doesn't catch: invented APIs that don't exist in the pinned version, over-defensive guards against impossible states, plausible-but-wrong docstrings, silent scope creep beyond the task's `Satisfies:` IDs, and tests that were adjusted to match the implementation instead of describing the behavior.
+
+Generic review training tells you to look for "bugs" and "readability." Neither framework surfaces these patterns. The review needs to be AI-aware.
+
+**The rule:** on any PR marked `AI-assisted: yes`, complete the [AI-assisted PR review checklist](../tooling/templates/code-review-AI-CHECKLIST.md) before approving. Copy the checklist into the PR description or reference it with `✅ AI-assist review: checklist-v1 completed by @<reviewer>`.
+
+**What the checklist adds over generic review:**
+
+- Scope verification against `Satisfies:` IDs — catches when the agent "cleaned up adjacent code" without being asked.
+- API existence checks — catches hallucinated method signatures, config keys, CLI flags, env variables. Grep vendor docs; don't trust the snippet.
+- Plausible-but-wrong docstring detection — read the docstring and function body independently; if the docstring could describe any function in this codebase, it's hallucinated.
+- Defensive-coding detection — flags `null` checks on parameters that can't be null, `except: pass` blocks, swallowed promise rejections.
+- Test-modification scrutiny — if a test changed in the diff, the commit message must explain *why the old assertion was wrong*. "Adjusted test to match new behavior" is a red flag, not an explanation.
+
+Items marked `[blocking]` in the checklist are merge-blockers; don't approve with caveats. Walk the list top to bottom — the whole point is to force the pause.
+
+**When to skip the checklist.** When the diff was genuinely written by a human and the agent was only used for tab-completion or formatting, `AI-assisted: no` is honest. Don't checkbox-ritualize the process; either the checklist earns its time or it doesn't.
+
 ---
 
 ## Part 2: Prompting Claude Code within the method
@@ -357,6 +377,7 @@ If the method feels slow after five initiatives, look for these specific problem
 3. Check for test modifications in the diff. If tests were changed to match code, that's a flag.
 4. Check CLAUDE.md compliance. Any never-do rules violated?
 5. Check for unrequested scope. If the code does things tests don't require, that's a flag.
+6. If the PR is marked `AI-assisted: yes`, walk the [AI-assisted PR review checklist](../tooling/templates/code-review-AI-CHECKLIST.md) top to bottom.
 
 ### When something goes wrong
 

--- a/method/AI_Assisted_Development_Method_v3_2_1.md
+++ b/method/AI_Assisted_Development_Method_v3_2_1.md
@@ -1,4 +1,4 @@
-# AI-Assisted Development Method
+# AI-Assisted Development Method (AADM)
 
 **Version 3.2.1**
 
@@ -224,7 +224,7 @@ In most enterprise engagements, the client does not hand you a complete design d
 
 **Phase 0 sub-phases:**
 
-- **0a. Discovery.** Structured 1:1 conversations with the people who will use the system and the people who will sign off on acceptance. Fill in the client intake template at `docs/intake/<CLIENT>-<DATE>.md` (see the AI-Assisted Development Method bundle for the template). Every `[REQUIRED]` field must be filled — "UNKNOWN — need to ask X" is acceptable but counts as an open question.
+- **0a. Discovery.** Structured 1:1 conversations with the people who will use the system and the people who will sign off on acceptance. Fill in the client intake template at `docs/intake/<CLIENT>-<DATE>.md` (see the AADM bundle for the template). Every `[REQUIRED]` field must be filled — "UNKNOWN — need to ask X" is acceptable but counts as an open question.
 - **0b. Design-doc drafting.** Your tech lead (with Claude Code assist) drafts `docs/<INITIATIVE>.md` from the intake. Ten to fifteen pages for a first-milestone-worth of scope, not fifty. Use the prompt at the bottom of the intake template to hand the intake to Claude Code as structured input.
 - **0c. Ambiguity pass on the draft.** Claude Code lists every ambiguity in the drafted design doc. Questions get answered by follow-up with the client. Resolved questions become Qn IDs in the design doc.
 - **0d. Client review.** The client reads the draft, pushes back, negotiates scope. Output: a signed-off design document with stable IDs.

--- a/state-check/DOCUMENTATION.md
+++ b/state-check/DOCUMENTATION.md
@@ -10,7 +10,7 @@ State-check is a pair of tools — a Python CLI and a Claude Code skill — that
 
 > **"Where are we in the method right now, and what should I work on next?"**
 
-It exists because the AI-Assisted Development Method has real surface area. A mid-size engagement has a design doc, a SOW, a failures log, multiple sprints, CLAUDE.md, retros, and a set of conventions to follow. An engineer sitting down at the start of a session — especially if they've been away for a few days or joined recently — has to reconstruct "where are we?" before doing anything. That reconstruction is slow and error-prone. Worse, it's the exact moment when skipping steps is easiest, because nobody is watching.
+It exists because the AI-Assisted Development Method (AADM) has real surface area. A mid-size engagement has a design doc, a SOW, a failures log, multiple sprints, CLAUDE.md, retros, and a set of conventions to follow. An engineer sitting down at the start of a session — especially if they've been away for a few days or joined recently — has to reconstruct "where are we?" before doing anything. That reconstruction is slow and error-prone. Worse, it's the exact moment when skipping steps is easiest, because nobody is watching.
 
 State-check collapses that reconstruction into a 30-second run that tells you:
 

--- a/state-check/README.md
+++ b/state-check/README.md
@@ -1,6 +1,6 @@
 # State Check — CLI + Claude Code Skill
 
-A paired tool for detecting what state your repo is in and what to work on next, within the AI-Assisted Development Method.
+A paired tool for detecting what state your repo is in and what to work on next, within the AI-Assisted Development Method (AADM).
 
 ## What's here
 

--- a/state-check/scripts/state-check.py
+++ b/state-check/scripts/state-check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-state-check.py — Repo state detector for the AI-Assisted Development Method.
+state-check.py — Repo state detector for the AI-Assisted Development Method (AADM).
 
 Detects which mode the repo is in (client delivery v3.2.1 or Internal Product
 Mode), which stage/phase is active, and flags anything that requires attention.
@@ -529,7 +529,7 @@ def print_human_report(state: ModeState) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Detect current state of a repo using the AI-Assisted Development Method."
+        description="Detect current state of a repo using the AI-Assisted Development Method (AADM)."
     )
     parser.add_argument("--repo-root", default=".", help="Repository root (default: cwd).")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,4 +1,4 @@
-# Day-One Tooling for the AI-Assisted Development Method
+# Day-One Tooling for the AI-Assisted Development Method (AADM)
 
 This bundle contains the minimum tooling to start using the method on a new client repo:
 

--- a/tooling/scripts/reconcile.py
+++ b/tooling/scripts/reconcile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-reconcile.py — Sprint coverage check for the AI-Assisted Development Method.
+reconcile.py — Sprint coverage check for the AI-Assisted Development Method (AADM).
 
 Parses sprints/vN/PRD.md for requirement IDs and sprints/vN/TASKS.md for
 `Satisfies:` citations. For each requirement, verifies that either:

--- a/tooling/templates/CLAUDE.md
+++ b/tooling/templates/CLAUDE.md
@@ -160,7 +160,7 @@ when you have real entries.>
 
 ## Method rules (non-negotiable)
 
-These come from the AI-Assisted Development Method and apply to every session:
+These come from the AI-Assisted Development Method (AADM) and apply to every session:
 
 1. **Never start work on sprint vN+1 until sprint vN has been locked via `/sprint-close`.**
 2. **Every task has a `Satisfies:` line citing the design-doc requirement IDs it closes.**

--- a/tooling/templates/code-review-AI-CHECKLIST.md
+++ b/tooling/templates/code-review-AI-CHECKLIST.md
@@ -1,0 +1,65 @@
+# AI-Assisted PR Review Checklist
+
+Use this checklist on any PR where a coding agent (Claude Code, Copilot, Cursor, etc.) produced a material share of the diff. It targets failure modes that pattern-match as "AI code smell" — issues a human would usually catch but that pass review because the output *looks* correct.
+
+**How to use it:**
+
+1. Copy the checklist into the PR description (or reference it with "✅ AI-assist review: checklist-v1 completed by @reviewer").
+2. Walk items top-to-bottom. Check each one or leave a note explaining why it doesn't apply.
+3. If any item is a red flag, request changes — do **not** approve with caveats. The whole point of the checklist is to force the pause.
+4. Items marked **[blocking]** are merge-blockers when they fail. Other items are strongly-worded defaults you may override with written justification.
+
+---
+
+## 1. Scope
+
+- [ ] **[blocking] Diff matches the task's `Satisfies:` IDs.** No files changed outside what the IDs would require. If the diff touches code adjacent to the requirement "because it was messy," that's scope creep — either expand the task, open a new one, or revert the drift.
+- [ ] **[blocking] No silent `[DEFERRED]` tasks.** Any task that wasn't finished is either complete (checked off), explicitly deferred in TASKS.md with a follow-up issue link, or visible in the PR description as "not done."
+- [ ] **No dead code in the diff.** If a function, import, variable, or branch is added but never reached, delete it. Agents frequently hedge with unused helpers; the deletion is on you.
+
+## 2. Correctness
+
+- [ ] **Edge cases, not just the golden path.** Empty input, single-element input, duplicate input, `None`/`null`/`undefined`, unicode, timezone boundaries, off-by-one on loops, integer overflow where the language allows it. Tests exist for at least the ones that apply.
+- [ ] **[blocking] Tests weren't modified to match the code.** If a test changed in this PR, the commit message explains *why the old assertion was wrong*. Use `state-check.py` to surface recently-modified test files if unsure.
+- [ ] **[blocking] No invented APIs.** Every imported symbol, library method, CLI flag, config key, env variable, and type signature actually exists in the version pinned in lockfile/pyproject/package.json. Grep the vendor docs or `go doc` / `python -c 'import x; help(x.y)'` if you're not sure.
+- [ ] **Concurrency claims are earned.** If the diff calls something "thread-safe," "atomic," "idempotent," or "race-free," there is either a test demonstrating it or a line of prose explaining the invariant that makes it true.
+
+## 3. Error handling
+
+- [ ] **No defensive coding for impossible states.** If a caller can only pass a non-null value (type system, framework guarantee, upstream validation), the function should not check for null. Agents love to add belt-and-suspenders guards that obscure real bugs.
+- [ ] **Failures fail loudly.** `except: pass`, `catch { }`, swallowed promise rejections, ignored return codes — flag every one. If the error is genuinely ignorable, the code says *why* in one line.
+- [ ] **Error messages name what failed, not what was attempted.** `"failed to parse config at line 42: unexpected indent"` beats `"error loading config"`.
+
+## 4. Comments and documentation
+
+- [ ] **Comments describe *why*, not *what*.** Any comment that re-narrates the next line of code should be deleted. Agents over-comment; leave the non-obvious invariant and cut the rest.
+- [ ] **No comments that reference the agent or this task.** `# Added per user request`, `# Handles the case Claude identified`, `# Fix for the bug in the prompt` — all of these rot within a week. If the insight is load-bearing, put it in a commit message or design doc.
+- [ ] **No plausible-but-wrong docstrings.** Read the docstring and the function body independently. If the docstring could plausibly describe any function in this codebase, it's probably hallucinated. Rewrite it to describe *this* function.
+
+## 5. Security
+
+- [ ] **User input never reaches a shell, SQL query, HTML body, template, or eval-like construct unescaped.** Parameterized queries, templating engines with autoescape, `shlex.quote`, framework-provided sanitizers — one of these is in the path.
+- [ ] **No hardcoded secrets, keys, tokens, or credentials.** Not even in tests, not even in comments, not even "temporarily."
+- [ ] **No new outbound network calls the agent added on its own initiative.** Every `requests.get`, `fetch`, `subprocess` that wasn't in the task description gets explicit justification.
+
+## 6. Tests
+
+- [ ] **New behavior has new tests.** Not "the build passes" — actual test function(s) asserting the behavior introduced by the diff.
+- [ ] **Test names describe the behavior under test, not the implementation.** `test_returns_empty_list_when_input_is_empty` beats `test_parse_function_branch_3`.
+- [ ] **At least one test in categories D (adversarial/security) or E (property/mutation) for any code on a trust boundary or arithmetic hot path.** See the method's test matrix.
+- [ ] **No `@skip`, `xfail`, or `.only()` left in the diff** unless the skip has a follow-up issue linked in the comment.
+
+## 7. Fit with existing code
+
+- [ ] **Style matches the file, not the agent's defaults.** Indent, quote style, import ordering, naming conventions. If the surrounding file uses `snake_case` and the agent produced `camelCase`, fix it — don't let the codebase fork.
+- [ ] **No duplicated helpers.** If the agent reimplemented `debounce`, `uniq`, `chunk`, a retry wrapper, or a timestamp-formatter that already exists in the repo, use the existing one. Grep before accepting.
+- [ ] **No premature abstractions.** One caller ≠ generic helper. Three similar lines are fine; a `BaseGenericFactoryProvider<T>` for a two-call use case is not.
+
+## 8. Commit hygiene
+
+- [ ] **Commit messages explain intent.** "Add auth middleware" is worse than "Add auth middleware to satisfy SOW-§3.2 — blocks unauthenticated /admin/* access, returns 401 with Retry-After on rate limit."
+- [ ] **No commits with "claude" / "copilot" / agent-branded messages** that leak into the shared history. Re-author or squash before merge; the tool is an implementation detail.
+
+---
+
+**Origin.** This checklist is maintained at [tooling/templates/code-review-AI-CHECKLIST.md](.). Propose additions via PR with a concrete failure-mode example — items not tied to a real failure get cut in the next pruning pass.


### PR DESCRIPTION
## Summary

Two independent, low-risk changes bundled:

### 1. AADM as the project's memorable name

First mention in every doc expands to "AI-Assisted Development Method (AADM)"; subsequent mentions use AADM. The repo slug (`ai-assisted-development-method`) is deliberately unchanged — existing URLs, bookmarks, and blog links continue to work.

GitHub repo description updated to: "AADM — AI-Assisted Development Method. A structured process for shipping enterprise-grade software with Claude Code."

Files touched (10):
- README.md
- START-HERE.md
- handbook/Developer_Handbook.md
- method/AI_Assisted_Development_Method_v3_2_1.md
- tooling/README.md
- tooling/scripts/reconcile.py
- tooling/templates/CLAUDE.md
- state-check/README.md
- state-check/DOCUMENTATION.md
- state-check/scripts/state-check.py

### 2. `.claude/settings.json` for team-wide `acceptEdits`

```json
{ "permissions": { "defaultMode": "acceptEdits" } }
```

Auto-accepts file edits in Claude Code without prompting but still gates risky bash commands. Matches AADM's philosophy — automate what reviewers would check; don't bypass safety.

Per-user `.claude/settings.local.json` remains gitignored for individual preferences.

## Notes for reviewers

- Stacked on top of [#9](https://github.com/colaberry/ai-assisted-development-method/pull/9). Merge #9 first, then this; or rebase as needed.
- Small conflict expected with [#4](https://github.com/colaberry/ai-assisted-development-method/pull/4) on `state-check/scripts/state-check.py` (both branches touch the module docstring). Trivial to resolve.

## Test plan

- [x] `python3 state-check/scripts/state-check.py --help` still prints the updated description
- [x] Every "AI-Assisted Development Method" grep hit now has "(AADM)" attached on first mention
- [x] GitHub repo description reflects the new name

Generated with [Claude Code](https://claude.com/claude-code)
