### PR TITLE
docs: idiot-proof documentation across all surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,20 @@ Automate what you would otherwise ask reviewers to check, and make skipping step
 
 The method operates at two levels:
 
-- **Initiative level** — a multi-sprint effort to ship a design document. Preceded by **Phase 0** (discovery and design-doc authoring) when the client hasn't handed you a complete spec. Gated by `/gap` at the end.
-- **Sprint level** — one sprint of an initiative. Gated by `/sprint-close` before the next sprint can start.
+- **Initiative level** — a multi-sprint effort to ship a design document. Preceded by **Phase 0** (discovery and design-doc authoring; see the [client intake template](tooling/templates/client-intake-TEMPLATE.md)) when the client hasn't handed you a complete spec. Audited by [`/gap`](tooling/.claude/skills/gap.md) between sprints; `/sprint-close` refuses to lock when orphaned requirements remain.
+- **Sprint level** — one sprint of an initiative. Each task runs in two Claude Code sessions (`/dev-test` then `/dev-impl`) with a marker file gating the handoff. Gated by [`/sprint-close`](tooling/.claude/skills/sprint-close.md) before the next sprint can start.
 
 ## What this solves
 
-- **PRD → gap analysis → new PRD loops.** Solved by stable requirement IDs plus CI-enforced coverage.
-- **Vague client input instead of a spec.** Phase 0 with the intake template turns vague input into signed-off requirements.
-- **Sprint-skipping across multi-sprint initiatives.** Solved by `/sprint-close` as a structural gate.
-- **Silent descoping.** Solved by the `[DEFERRED]` discipline in tasks.
+- **PRD → gap analysis → new PRD loops.** Solved by stable requirement IDs plus CI-enforced coverage (`reconcile.py`).
+- **Vague client input instead of a spec.** Phase 0 with the intake template (Section 7.5 enumeration discipline) turns vague input into signed-off requirements.
+- **Silent requirement drop across multi-sprint initiatives.** A requirement in the design doc that never makes it into any sprint. Solved by `/gap` (script + skill) plus `sprint_close.py` refusal-on-orphans plus a `state-check.py` P1 flag for stale analyses.
+- **Sprint-skipping.** Cannot start v(N+1) while v(N) is unlocked. Solved by `/sprint-close` writing the `.lock` and `sprint_gate.py` PreToolUse hook blocking writes.
+- **Silent scope expansion.** Implementation phases drifting past declared scope. Solved by `sprint_gate.py` enforcing a `Files:` allowlist parsed from the active TASKS.md.
+- **Test-after-the-fact masquerading as TDD.** Single-session "/dev that writes tests then implements" lets the model coerce tests to match code. Solved by splitting into `/dev-test` (writes failing matrix, commits) and `/dev-impl` (separate session; refuses to start until `dev_session.py` verifies the test commit on disk).
+- **Silent descoping.** Solved by `[DEFERRED]` discipline (target sprint + reason required).
 - **Tests that look thorough but miss real bugs.** Solved by the test matrix (categories D and E specifically) plus periodic mutation testing.
-- **Repeating the same class of bug.** Solved by the failures log feeding forward into new design docs.
+- **Repeating the same class of bug.** Solved by the failures log feeding forward into new design docs and the `/incident` skill naming an enforcement surface for every prevention rule.
 
 ## What's in this repo
 
@@ -45,13 +48,22 @@ If you want to adopt AADM on an existing project but can't take a full-bundle bo
 
 ```mermaid
 flowchart LR
+    SOW["Contract<br/>docs/contract/SOW.md<br/>(SOW-§X.Y IDs)"] -->|"Satisfies:"| Design
+    Intake["Phase 0 intake<br/>docs/intake/*.md<br/>(Section 7.5 completeness pass)"] -->|"feeds"| Design
+
     Design["Design doc<br/>docs/INITIATIVE.md<br/>(stable IDs)"] -->|"Satisfies:"| PRD
-    SOW["Contract<br/>docs/contract/SOW.md<br/>(SOW-#X.Y IDs)"] -->|"Satisfies:"| Design
+    Design -->|"audited by"| Gap
 
-    PRD["/prd vN<br/>sprints/vN/PRD.md<br/>+ TASKS.md"]
-    PRD --> Dev["/dev<br/>one task per session<br/>tests in separate session"]
+    Gap{{"/gap<br/>(gap.py + skill)<br/>orphan + completeness audit"}}
+    Gap -.->|"orphans \u2192 amend / defer"| Design
 
-    Dev --> PR["Open PR"]
+    PRD["/prd vN<br/>sprints/vN/PRD.md<br/>+ TASKS.md (Files: allowlist)"]
+    PRD --> Test["/dev-test<br/>(session 1)<br/>writes failing matrix<br/>+ commits<br/>+ marker file"]
+    Test --> Impl["/dev-impl<br/>(session 2)<br/>dev_session.py check-impl-ready<br/>refuses without marker"]
+
+    Impl --> PR["Open PR"]
+
+    Hook["sprint_gate.py<br/>PreToolUse hook"] -.->|"blocks writes outside Files: allowlist<br/>or under future sprint"| Impl
 
     PR --> GR{{"reconcile.py --ci"}}
     PR --> GS{{"security.yml<br/>(Semgrep)"}}
@@ -60,22 +72,33 @@ flowchart LR
     GR -.->|"fail"| Block["Merge blocked"]
     GS -.->|"fail"| Block
 
-    Close["/sprint-close<br/>- runs reconcile again<br/>- /retro, /walkthrough<br/>- /security-review if in scope<br/>- /ui-qa if in scope<br/>- check_sessions_logged"]
+    Close["/sprint-close<br/>- reconcile --ci<br/>- /gap orphan check<br/>- /retro, /walkthrough<br/>- /security-review if in scope<br/>- /ui-qa if in scope<br/>- check_sessions_logged"]
     Close --> Lock{{"sprint_close.py<br/>writes .lock"}}
     Lock -->|"locked"| NextPRD["/prd vN+1<br/>(unblocked)"]
     Lock -.->|"any check fails"| Refuse["Refuses; no .lock written"]
 
-    Hook["sprint_gate.py<br/>PreToolUse hook"] -.->|"blocks Edit/Write under<br/>sprints/vN+1 until .lock"| NextPRD
+    Hook -.->|"blocks Edit/Write under<br/>sprints/vN+1 until .lock"| NextPRD
 
     style GR fill:#1e3a8a,color:#fff
     style GS fill:#1e3a8a,color:#fff
     style Lock fill:#1e3a8a,color:#fff
+    style Gap fill:#1e3a8a,color:#fff
+    style Hook fill:#1e3a8a,color:#fff
     style Block fill:#7f1d1d,color:#fff
     style Refuse fill:#7f1d1d,color:#fff
     style Close fill:#064e3b,color:#fff
+    style Test fill:#064e3b,color:#fff
+    style Impl fill:#064e3b,color:#fff
 ```
 
-Blue = structural gate (non-skippable). Red = refusal path. Green = ceremony. Every box maps to a script or a skill in the tooling.
+**Blue** = structural gate (non-skippable). **Red** = refusal path. **Green** = ceremony. Every box maps to a script or a skill in [tooling/](tooling/).
+
+**The typical sprint, at the engineer's eye level:**
+
+1. `/prd` reads the design doc, scopes this sprint, writes `PRD.md` + `TASKS.md` (each task carries a `Files:` allowlist).
+2. For each task: `/dev-test` writes the failing test matrix, commits, drops a marker. **Open a new Claude Code session.** `/dev-impl` verifies the marker and implements until tests pass.
+3. PR opens. `reconcile.py --ci` (traceability) and `security.yml` (Semgrep) gate the merge.
+4. End of sprint: `/gap` audits initiative-level coverage. `/sprint-close` runs all the checks and writes `.lock`. The PreToolUse hook now permits writes under `sprints/v(N+1)/`.
 
 ## Reading order by role
 
@@ -85,23 +108,51 @@ Blue = structural gate (non-skippable). Red = refusal path. Green = ceremony. Ev
 
 ## Tooling
 
-- **[sprint_close.py](tooling/scripts/sprint_close.py)** — atomic sprint closure. Runs `reconcile.py --ci`, verifies `RETRO.md` is filled (no template markers, sections 1-2 have real content), verifies `SIGNOFF.md` exists with `Reviewer:` + `Date:` (or accepts `--reviewer NAME` to create one), then writes `sprints/vN/.lock` recording who closed the sprint and when. No partial closures. Python stdlib only.
-- **[reconcile.py](tooling/scripts/reconcile.py)** — sprint coverage check. Verifies every PRD requirement is satisfied by a completed task or marked `[DEFERRED]`, that listed `Files:` exist, and (new) that symbols extracted from each task's title and `Acceptance:` line actually appear in those files — closes the "empty stub passes reconcile" hole. `--strict-symbols` opts into hard-failing on stubs. Python stdlib only. Runs in CI via [reconcile.yml](tooling/.github/workflows/reconcile.yml) as a merge gate.
-- **[security.yml](tooling/.github/workflows/security.yml)** — Semgrep-based security merge gate. Blocks PRs on any ERROR-severity finding. Deliberate suppressions live in [docs/security/suppressions.md](tooling/templates/security-suppressions-TEMPLATE.md) with a 90-day re-review ceremony enforced by `state-check.py`.
-- **[sprint_gate.py](tooling/hooks/sprint_gate.py)** — Claude Code `PreToolUse` hook. Blocks `Write`/`Edit`/`MultiEdit`/`NotebookEdit` under `sprints/vK/` when any earlier `sprints/vJ/` (J < K) is missing a `.lock` file. The structural complement to `sprint_close.py`: `sprint_close.py` decides when `.lock` gets written, `sprint_gate.py` decides what the agent can touch based on whose `.lock` exists. Install via [claude-settings-hooks-TEMPLATE.json](tooling/templates/claude-settings-hooks-TEMPLATE.json).
-- **[state-check.py](state-check/scripts/state-check.py)** — detects current repo state (mode, stage, active sprint, flags). Heads-up display, not autopilot. Ships with a [Claude Code skill](state-check/.claude/skills/state-check.md) for conversational use.
-- **[metrics.py](metrics/scripts/metrics.py)** — append-only event log for development metrics. Two event types ship: **gate events** (Phase 1 — CI workflows call `log-gate` on every gate run; pass/fail records accumulate as JSONL) and **session events** (Phase 2 partial — engineers run `log-session` at the end of each work session; `sprint_close.py` refuses to lock a sprint with zero logged sessions when the metrics module is installed, so the discipline is structural). Threshold ranges that *interpret* session counts (healthy / high / low, rework-rate alerts) are deliberately deferred until one engagement has run 3+ sprints under both event types — calibration against simulated data misleads. See [metrics/docs/METRICS.md](metrics/docs/METRICS.md).
-- **[/incident skill](tooling/.claude/skills/incident.md)** — post-deployment learning loop. Orchestrates the post-mortem using [incident-TEMPLATE.md](tooling/templates/incident-TEMPLATE.md), extracts a specific prevention rule into `docs/failures/`, names the enforcement surface where the rule will actually run (CLAUDE.md / CI / architecture-guard test / security prompt / test-matrix), and optionally drafts a design-doc update PR or a superseding ADR when an incident invalidates a requirement. Completes the SDLC coverage that today stops at sprint close. Open incidents (post-mortems without a `Resolved:` timestamp) are surfaced as P1 learning-loop flags by `state-check.py`.
-- **Method skills** — conversational wrappers around the enforcement scripts: [/prd](tooling/.claude/skills/prd.md) scopes a single sprint from the design document and produces `sprints/vN/PRD.md` + `TASKS.md` that `reconcile.py` parses; [/dev](tooling/.claude/skills/dev.md) executes one task per session, enforces the test-matrix categories named in `Tests required:`, and reads the task's `Autonomy:` annotation to tune checkpoint cadence; [/sprint-close](tooling/.claude/skills/sprint-close.md) wraps `sprint_close.py` and walks the engineer through `RETRO.md`, sign-off, and the security/UI-QA escalation when the PRD said they were required.
-- **Gate ceremony skills** — Internal Product Mode graduation gates: [/gate-1-to-2](tooling/.claude/skills/gate-1-to-2.md) runs the Stage 1 → 2 evidence interview (real problem, real users, named commitment) and produces `docs/gates/stage-1-to-2.md`; [/gate-2-to-3](tooling/.claude/skills/gate-2-to-3.md) runs the Stage 2 → 3 commercialization gate, including the structural pre-committed-retention check (the metric and threshold must be in the Stage 2 PRD *before* the data is read), and produces `docs/gates/stage-2-to-3.md`. Both refuse to graduate without explicit evidence and named decisions.
-- **[AI-assisted PR review checklist](tooling/templates/code-review-AI-CHECKLIST.md)** — ~25-item checklist reviewers attach to PRs marked `AI-assisted: yes`. Targets AI-specific failure modes generic PR review misses: invented APIs, plausible-but-wrong docstrings, defensive coding for impossible states, silent scope creep beyond the task's `Satisfies:` IDs, tests modified to match implementation. `[blocking]` items are merge-blockers. The [.github/pull_request_template.md](.github/pull_request_template.md) carries the `AI-assisted: yes / no` field that points reviewers at the checklist; handbook §1.8 covers when to skip it honestly.
-- **Templates** — [CLAUDE.md](tooling/templates/CLAUDE.md), [client intake](tooling/templates/client-intake-TEMPLATE.md), [sprint PRD](tooling/templates/sprint-PRD-TEMPLATE.md), [tasks](tooling/templates/sprint-TASKS-TEMPLATE.md), [failures log](tooling/templates/failures-log-TEMPLATE.md), [retro](tooling/templates/retro-TEMPLATE.md), [security suppressions](tooling/templates/security-suppressions-TEMPLATE.md), [incident post-mortem](tooling/templates/incident-TEMPLATE.md), [AI-assisted PR review checklist](tooling/templates/code-review-AI-CHECKLIST.md).
+### Structural enforcement (these block work that would otherwise pass)
+
+| Tool | What it does |
+|---|---|
+| [`reconcile.py`](tooling/scripts/reconcile.py) | Sprint coverage check. Every PRD requirement must be satisfied by a completed task or `[DEFERRED]` with target. Symbol-presence check catches "empty stub passes reconcile." `--strict-symbols` hard-fails on stubs. Runs in CI via [reconcile.yml](tooling/.github/workflows/reconcile.yml). |
+| [`gap.py`](tooling/scripts/gap.py) | Initiative-boundary coverage check. Diffs design-doc stable IDs against the union of `Satisfies:` lines across all sprints. Emits `docs/<INITIATIVE>_GAP_ANALYSIS.md` with covered / deferred / orphaned / conflicted sections. v1 handles single-hop `SUPERSEDED-BY:`. Driven by [/gap](tooling/.claude/skills/gap.md). |
+| [`sprint_close.py`](tooling/scripts/sprint_close.py) | Atomic sprint closure. Runs reconcile, refuses on `/gap` orphans, verifies `RETRO.md` is real (not template stub), verifies `SIGNOFF.md`, runs scope-artifact checks (`/security-review` and `/ui-qa` artifacts when the PRD flagged them required), refuses if zero session events were logged when `metrics/` is installed. Writes `sprints/vN/.lock` only when every check passes. Python stdlib only. |
+| [`sprint_gate.py`](tooling/hooks/sprint_gate.py) | Claude Code `PreToolUse` hook. Two enforcement modes: (1) blocks writes under `sprints/vK/` when an earlier `sprints/vJ/` (J<K) lacks `.lock`; (2) when a prior sprint is unlocked, blocks writes outside the active TASKS.md `Files:` allowlist (open `[ ]` tasks only — `[x]` and `[DEFERRED]` excluded). Logs blocks to `sprints/vN/.gate-blocks.log`. Install via [claude-settings-hooks-TEMPLATE.json](tooling/templates/claude-settings-hooks-TEMPLATE.json). |
+| [`security.yml`](tooling/.github/workflows/security.yml) | Semgrep merge gate. Blocks PRs on any ERROR-severity finding. Deliberate suppressions live in `docs/security/suppressions.md` (template at [security-suppressions-TEMPLATE.md](tooling/templates/security-suppressions-TEMPLATE.md)) with a 90-day re-review ceremony enforced by state-check. |
+| [`dev_session.py`](tooling/scripts/dev_session.py) | Marker-file enforcement for the `/dev-test` → `/dev-impl` session split. `test-done` writes `sprints/vN/.in-progress/T-NNN.test-session-done` with the test commit SHA. `check-impl-ready` refuses the implementation session unless the marker exists, is well-formed, and the recorded commit is verifiable on disk. `mark-complete` moves the marker to `T-NNN.complete`. Method rule 4 made structural. |
+
+### Skills (conversational wrappers around the scripts)
+
+| Skill | When to run it |
+|---|---|
+| [`/prd`](tooling/.claude/skills/prd.md) | Start of sprint. Scopes from the design doc, runs the scoped-completeness pass (step 4), produces `PRD.md` + `TASKS.md` with `Files:` allowlist on each task. |
+| [`/dev-test`](tooling/.claude/skills/dev-test.md) | Session 1 of every task. Writes the failing test matrix (categories A–E per `Tests required:`), commits, drops the `dev_session.py` marker. |
+| [`/dev-impl`](tooling/.claude/skills/dev-impl.md) | Session 2 of every task — **must be a new Claude Code session**. Refuses to start until `dev_session.py check-impl-ready` succeeds. Implements until the matrix passes. Runs `mark-complete` on done. |
+| [`/dev`](tooling/.claude/skills/dev.md) | Router only. Points the engineer at `/dev-test` or `/dev-impl` based on whether a marker exists. |
+| [`/gap`](tooling/.claude/skills/gap.md) | Between sprints, before `/sprint-close`. Runs the script, walks the engineer through orphans and conflicts, performs the upstream-completeness pass against intake §7.5, commits the analysis. |
+| [`/sprint-close`](tooling/.claude/skills/sprint-close.md) | End of sprint. Wraps `sprint_close.py`. Walks the engineer through `RETRO.md` (template-stub answers rejected structurally), sign-off, and `/security-review` / `/ui-qa` escalation when the PRD said they were required. Refuses lock on any check failure. |
+| [`/security-review`](tooling/.claude/skills/security-review.md) | When the sprint PRD declares `` `/security-review` required: Yes ``. Produces `sprints/vN/SECURITY-REVIEW.md`; `Decision: blocked` blocks the lock. |
+| [`/ui-qa`](tooling/.claude/skills/ui-qa.md) | When the sprint PRD declares `` `/ui-qa` required: Yes ``. Produces `sprints/vN/UI-QA.md`; `Decision: blocked` blocks the lock. |
+| [`/incident`](tooling/.claude/skills/incident.md) | Post-deployment learning loop. Orchestrates the post-mortem, extracts a prevention rule into `docs/failures/`, names the enforcement surface (CLAUDE.md / CI / architecture guard / security prompt / test matrix). Open incidents flagged P1 by state-check. |
+| [`/gate-1-to-2`](tooling/.claude/skills/gate-1-to-2.md), [`/gate-2-to-3`](tooling/.claude/skills/gate-2-to-3.md) | Internal Product Mode graduation gates. Stage 2→3 enforces the pre-committed retention metric (must be in the Stage 2 PRD *before* the data is read). |
+
+### Heads-up display
+
+| Tool | What it does |
+|---|---|
+| [`state-check.py`](state-check/scripts/state-check.py) | Detects mode, stage, active sprint, and flags. Surfaces P0 (blocking) / P1 (warn) / P2 (nudge). Includes `check_gap_analysis_staleness` (P1 when `docs/<INITIATIVE>_GAP_ANALYSIS.md` is missing or older than the newest sprint `.lock`). Ships with a conversational [skill](state-check/.claude/skills/state-check.md). |
+| [`metrics.py`](metrics/scripts/metrics.py) | Append-only JSONL event log at `docs/metrics/events.jsonl`. Gate events (Phase 1, automatic from CI) and session events (Phase 2, manual `log-session`). `sprint_close.py` refuses zero-session sprints when `metrics/` is installed. Threshold interpretation deliberately deferred — see [METRICS.md](metrics/docs/METRICS.md). |
+
+### Process artifacts
+
+- [AI-assisted PR review checklist](tooling/templates/code-review-AI-CHECKLIST.md) — ~25-item checklist for PRs marked `AI-assisted: yes` in [.github/pull_request_template.md](.github/pull_request_template.md). Targets AI-specific failure modes (invented APIs, plausible-but-wrong docstrings, defensive coding for impossible states, silent scope creep, tests modified to match implementation).
+- Templates under [tooling/templates/](tooling/templates/) — CLAUDE.md, client intake (Section 7.5 = enumeration discipline), sprint PRD, sprint TASKS (`Files:` is load-bearing — see template), retro, failures log, security suppressions, incident post-mortem, security review, UI QA.
 
 ## What this deliberately does NOT include yet
 
-- **Automation for `/gap`, `/ui-qa`** — currently manual checklists. Promote to scripts after the manual process has stabilized on at least one engagement. (Security has moved from checklist to structural gate via [security.yml](tooling/.github/workflows/security.yml); manual `/security-review` remains as the escalation path for deeper human review. `/sprint-close` is now scripted via [sprint_close.py](tooling/scripts/sprint_close.py).)
-- **Enforcement hooks** — structural cross-sprint write blocking now ships via [sprint_gate.py](tooling/hooks/sprint_gate.py) as a `PreToolUse` hook. Cultural discipline graduated to structural enforcement.
 - **Mutation testing setup** — language-specific; add when you pick critical modules.
+- **Threshold interpretation for session metrics** (follow-up to [#13](https://github.com/colaberry/ai-assisted-development-method/issues/13)) — the structural pieces shipped (`log-session`, `sprint_close.py` zero-sessions refusal, retro template section). Threshold ranges (healthy / high / low session counts, rework-rate alerts) and the rollup CLI are deliberately deferred until at least one engagement has run 3+ sprints under both gate and session logging. Calibrating against simulated data misleads more than it informs.
+- **Multi-hop `SUPERSEDED-BY:` chain semantics for `/gap`** ([#29](https://github.com/colaberry/ai-assisted-development-method/issues/29)) — v1 handles single-hop supersession; full chain resolution is a separate piece.
+
+(Earlier "not yet" items — `/gap` automation, `/security-review` and `/ui-qa` skills, `sprint-close` automation, the cross-sprint hook, the test/impl session split — have all shipped. See [CHANGELOG.md](CHANGELOG.md).)
 
 ## Status
 

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -24,20 +24,36 @@ This bundle contains everything needed to adopt AADM on a new or existing client
 │   │   └── state-check.py                     # Repo state detector CLI (tested, works)
 │   └── .claude/skills/
 │       └── state-check.md                     # Claude Code conversational skill
+├── metrics/
+│   ├── scripts/metrics.py                     # Gate + session event logger
+│   └── docs/METRICS.md                        # Event schema and usage
 └── tooling/
     ├── README.md                              # Tooling-specific setup guide
     ├── scripts/
-    │   └── reconcile.py                       # Sprint coverage check (tested, works)
+    │   ├── reconcile.py                       # Sprint coverage check (CI merge gate)
+    │   ├── gap.py                             # Initiative-boundary coverage check
+    │   ├── sprint_close.py                    # Atomic sprint closure (writes .lock)
+    │   └── dev_session.py                     # Marker enforcement for /dev-test → /dev-impl
+    ├── hooks/
+    │   └── sprint_gate.py                     # PreToolUse hook: anti-skip + Files: allowlist
     ├── .github/workflows/
-    │   └── reconcile.yml                      # CI merge gate
+    │   ├── reconcile.yml                      # CI merge gate (traceability)
+    │   └── security.yml                       # CI merge gate (Semgrep)
+    ├── .claude/skills/                        # Conversational skills (/prd, /dev-test, /dev-impl, /gap, /sprint-close, /security-review, /ui-qa, /incident, /gate-1-to-2, /gate-2-to-3)
     └── templates/
-        ├── client-intake-TEMPLATE.md          # Phase 0 intake — capture requirements from vague client input
+        ├── client-intake-TEMPLATE.md          # Phase 0 intake (Section 7.5 = completeness pass)
         ├── CLAUDE.md                          # Per-client persistent context
+        ├── sprint-PRD-TEMPLATE.md             # Sprint planning document
+        ├── sprint-TASKS-TEMPLATE.md           # Task list (Files: entries are the hook allowlist)
+        ├── retro-TEMPLATE.md                  # Per-sprint retrospective
         ├── failures-log-README.md             # Folder README for docs/failures/
         ├── failures-log-TEMPLATE.md           # Single failures-log entry template
-        ├── retro-TEMPLATE.md                  # Per-sprint retrospective
-        ├── sprint-PRD-TEMPLATE.md             # Sprint planning document
-        └── sprint-TASKS-TEMPLATE.md           # Task list (format /reconcile parses)
+        ├── incident-TEMPLATE.md               # Post-mortem template
+        ├── security-review-TEMPLATE.md        # /security-review artifact
+        ├── ui-qa-TEMPLATE.md                  # /ui-qa artifact
+        ├── security-suppressions-TEMPLATE.md  # Semgrep suppression ledger
+        ├── code-review-AI-CHECKLIST.md        # Attach to AI-assisted PRs
+        └── claude-settings-hooks-TEMPLATE.json # Merge into client repo .claude/settings.json
 ```
 
 ## Reading order
@@ -90,20 +106,23 @@ A structured process for shipping enterprise-grade software to external clients 
 
 The method operates at two levels:
 
-- **Initiative level** — a multi-sprint effort to ship a design document. Preceded by **Phase 0** (discovery and design-doc authoring) when the client hasn't provided a complete spec. Gated by `/gap` at the end.
-- **Sprint level** — one sprint of an initiative. Gated by `/sprint-close` before the next sprint can start.
+- **Initiative level** — a multi-sprint effort to ship a design document. Preceded by **Phase 0** (discovery and design-doc authoring; intake template Section 7.5 walks an enumeration checklist so requirements aren't silently dropped before they can get an ID) when the client hasn't provided a complete spec. Audited by `/gap` (script + skill); `/sprint-close` refuses to lock when orphaned requirements remain.
+- **Sprint level** — one sprint of an initiative. Each task runs in two Claude Code sessions: `/dev-test` writes the failing matrix and commits, then a **new session** runs `/dev-impl` (which refuses to start until `dev_session.py` verifies the test commit). Gated by `/sprint-close` before the next sprint can start.
 
-Requirements have stable IDs (§X.Y, Dn, Qn, SOW-§X.Y) that propagate from the contract through the design doc, sprint PRDs, and tasks to code. The `/reconcile` script enforces traceability in CI.
+Requirements have stable IDs (§X.Y, Dn, Qn, SOW-§X.Y) that propagate from the contract through the design doc, sprint PRDs, and tasks to code. The `/reconcile` script enforces traceability in CI; the `sprint_gate.py` PreToolUse hook enforces the per-task `Files:` allowlist.
 
 ## What problem this solves
 
 - **PRD → gap analysis → new PRD → gap analysis loops.** Solved by stable requirement IDs plus CI-enforced coverage.
-- **Client gave us a vague problem statement, not a spec.** Phase 0 with the intake template turns vague input into signed-off requirements before sprint work begins.
-- **Sprint-skipping across multi-sprint initiatives.** Solved by `/sprint-close` as a structural gate.
-- **Silent descoping.** Solved by the `[DEFERRED]` discipline in tasks.
+- **Client gave us a vague problem statement, not a spec.** Phase 0 with the intake template (Section 7.5 enumeration discipline) turns vague input into signed-off requirements before sprint work begins.
+- **Silent requirement drop across an initiative.** A requirement in the design doc that never makes it into any sprint. Solved by `/gap` (script + skill) plus `sprint_close.py` refusal-on-orphans plus a `state-check.py` P1 flag for stale analyses.
+- **Sprint-skipping.** Solved by `/sprint-close` writing the `.lock` and `sprint_gate.py` PreToolUse hook blocking writes under `sprints/v(N+1)/` until v(N) is locked.
+- **Silent scope expansion.** Implementation drifting past declared scope. Solved by `sprint_gate.py` enforcing a `Files:` allowlist parsed from the active TASKS.md.
+- **Test-after-the-fact masquerading as TDD.** Solved by splitting `/dev` into `/dev-test` (writes failing matrix, commits) and `/dev-impl` (separate session; refuses to start until `dev_session.py` verifies the test commit).
+- **Silent descoping.** Solved by `[DEFERRED]` discipline (target sprint + reason required).
 - **LLM-written tests that look thorough but don't catch real bugs.** Solved by the test matrix (categories D and E specifically) plus periodic mutation testing.
 - **Client delivery surprises.** Solved by client-facing artifacts that are projections of internal artifacts, never written independently.
-- **Repeating the same class of bug.** Solved by the failures log feeding forward into new design docs.
+- **Repeating the same class of bug.** Solved by the failures log feeding forward into new design docs and the `/incident` skill naming an enforcement surface for every prevention rule.
 
 ## Getting started
 
@@ -189,12 +208,15 @@ If you're using Phase 0, steps 3 and 4 are outputs of Phase 0 — you don't do t
 
 Follow the method's Sprint Level section:
 
-1. `/prd` — scope the sprint from the design doc. Every task gets a `Satisfies:` line.
-2. `/dev` — one task per session, test matrix first (categories A–E), separate sessions for tests and implementation.
-3. `/reconcile` — runs in CI on every PR. Blocks merges when requirements aren't covered.
-4. `/sprint-close` — runs `/reconcile`, `/walkthrough`, `/retro`, and writes the lockfile.
+1. `/prd` — scope the sprint from the design doc. Every task gets a `Satisfies:` line and a `Files:` allowlist (the hook enforces it). The skill walks a scoped completeness pass before slicing tasks.
+2. **For each task, two Claude Code sessions:**
+   - `/dev-test` — writes the failing test matrix (categories A–E per `Tests required:`), commits, drops the `dev_session.py` marker.
+   - **Open a new Claude Code session.** `/dev-impl` — runs `dev_session.py check-impl-ready` first, refuses without the marker, implements until the matrix passes.
+3. `/reconcile` — runs in CI on every PR. Blocks merges when requirements aren't covered. `security.yml` runs Semgrep alongside it.
+4. `/gap` — between sprints, before `/sprint-close`. Runs `gap.py`, walks orphans interactively, performs the upstream-completeness pass against intake §7.5, commits `docs/<INITIATIVE>_GAP_ANALYSIS.md`.
+5. `/sprint-close` — wraps `sprint_close.py`. Runs reconcile again, refuses on `/gap` orphans, validates RETRO.md isn't a template stub, requires `/security-review` and `/ui-qa` artifacts when the PRD flagged them, refuses on zero session events when `metrics/` is installed, then writes `sprints/vN/.lock`.
 
-`/sprint-close` and `/walkthrough` are manual checklists for now; automate them after you've used them for a few sprints.
+`/walkthrough` is the only step still primarily a manual ceremony. Everything else above is scripted with structural refusal modes.
 
 ### Step 6: Watch for the common skips
 
@@ -204,26 +226,28 @@ From honest prediction: these will happen in your first initiative.
 2. The test matrix D (fallthrough) gets skipped on a "small" task. It won't feel necessary until something breaks.
 3. The ambiguity pass produces questions, they get answered in Slack, nobody updates the design doc. Check whether the doc actually got edited.
 4. The failures log accumulates entries faster than prevention rules. Each entry needs a rule, or the log becomes a graveyard.
-5. **New:** Phase 0 gets rushed. Intake has `[REQUIRED]` fields marked "TBD" and the design doc gets written against the gaps. Enforce the handoff-readiness checklist in Section 13 of the intake template.
+5. Phase 0 gets rushed. Intake has `[REQUIRED]` fields marked "TBD" and the design doc gets written against the gaps. Enforce the Section 13 handoff-readiness checklist — and specifically the Section 7.5 completeness pass, which forces an explicit "N/A because X" per category rather than silent drop.
 
 ## Version notes
 
 - **Method:** v3.2.1 — adds Phase 0 and the client intake template to v3.2. If you were already planning to use v3.2, v3.2.1 is a drop-in replacement.
-- **Tooling:** day-one essentials plus the intake template. `/reconcile` is a tested working script; `/sprint-close`, `/gap`, `/security-review`, and `/ui-qa` are manual checklists until your team has used the basics for a while.
+- **Tooling:** the structural enforcement points are all scripted now — `reconcile.py`, `gap.py`, `sprint_close.py`, `sprint_gate.py` (PreToolUse hook), `security.yml` (Semgrep), `dev_session.py` (test/impl session split), and the `/security-review` + `/ui-qa` skills with structural refusal in `sprint_close.py`. See [CHANGELOG.md](CHANGELOG.md) for what shipped in each release.
 
-## What this bundle deliberately does NOT include
+## What this bundle deliberately does NOT include yet
 
-- **`/sprint-close`, `/walkthrough`, `/gap`, `/security-review`, `/ui-qa` automation scripts.** Higher-leverage to build once the manual versions have stabilized.
 - **Mutation testing setup.** Language-specific; add when you pick critical modules.
+- **Threshold interpretation for session metrics** (follow-up to [#13](https://github.com/colaberry/ai-assisted-development-method/issues/13)). Structural pieces shipped (logging, refusal-on-zero); threshold ranges deliberately deferred until at least one engagement has run 3+ sprints under both gate and session logging.
+- **Multi-hop `SUPERSEDED-BY:` chains in `/gap`** ([#29](https://github.com/colaberry/ai-assisted-development-method/issues/29)) — v1 handles single-hop only.
+- **`/walkthrough` script** — the manual ceremony works fine and there's no failure-mode evidence yet that demands a script.
 
 ## Quick reference — the 15 rules
 
 From the method document:
 
-1. One sprint at a time per initiative stream.
-2. One task at a time per `/dev` session.
+1. One sprint at a time per initiative stream. (Enforced by `sprint_gate.py` + `.lock`.)
+2. One task at a time per `/dev-test` or `/dev-impl` session.
 3. Never skip the test matrix. Categories D and E matter most when they feel least necessary.
-4. Test writing and implementation are in separate Claude Code sessions.
+4. Test writing and implementation are in separate Claude Code sessions. (Enforced by `dev_session.py` marker verification.)
 5. Never accept "it should work" without running it.
 6. When Claude Code gets stuck in a loop, stop and re-specify.
 7. Keep CLAUDE.md, decision records, and the failures log current.

--- a/handbook/Developer_Handbook.md
+++ b/handbook/Developer_Handbook.md
@@ -103,11 +103,11 @@ Before writing any test code, you write down the plan. Five categories. You do t
 
 **Category E is where teams leak architectural decay.** Example: you delete a deprecated function. Three months later someone re-adds it because they didn't know it was deprecated. An E test that asserts `assert 'old_function' not in inspect.getsource(auth_module)` prevents this.
 
-### 1.3 Separate sessions for tests and implementation
+### 1.3 Separate sessions for tests and implementation (`/dev-test` → `/dev-impl`)
 
-This is the single most important practical rule in the method. It's also the one most engineers initially dismiss as ceremony.
+This is the single most important practical rule in the method. It's also the one most engineers initially dismiss as ceremony — which is why it is now structurally enforced.
 
-**The mechanic:** Start a fresh Claude Code session for writing tests. Close it. Start a new one for implementation. The new session reads the committed failing tests as input but has no context on what the intended implementation looks like.
+**The mechanic:** Run `/dev-test` in a fresh Claude Code session to write the failing tests. Commit them. The skill drops a marker file naming the task and the commit SHA of the tests. Close the session. Open a new one and run `/dev-impl`. It refuses to start unless the marker exists and the current session is a different session from the one that wrote the tests — that check is done by `dev_session.py`. The implementation session reads the committed failing tests as input but has no context on what the intended implementation looks like.
 
 **Why it matters:** When Claude Code can see the implementation being planned, it writes tests that match the implementation. That's not test-first development; that's elaborate test-after dressed up as TDD. You get tests that pass when the code ships and that still pass when the code is broken, because they were written to describe the code, not the behavior.
 
@@ -157,7 +157,7 @@ The good rule is specific enough that you could implement it as a linter check o
 **Where every prevention rule has to live.** Check at least one box. An entry without a "lives in" placement is a wish, not a rule.
 
 - [ ] Added to CLAUDE.md under "Never-do rules"
-- [ ] Added to `/dev` Step 2.5 test-matrix guidance for category X
+- [ ] Added to `/dev-test` Step 2.5 test-matrix guidance for category X
 - [ ] Added as a CI check
 - [ ] Implemented as an architecture-guard test (Category E)
 - [ ] Added to `/security-review` or ambiguity-pass prompt
@@ -191,7 +191,7 @@ You are in the wrong place if any of these are true:
 - You keep discovering new requirements that weren't in the PRD.
 - You've modified tests twice to make them match what the code is actually doing.
 
-These are not implementation problems. They are specification problems, and they won't be fixed by more `/dev` rounds. Stop, go back to `sprints/vN/PRD.md` or `docs/<INITIATIVE>.md`, and re-read the relevant section. If the spec is genuinely ambiguous, run a focused ambiguity pass and produce questions for a human — do not invent answers.
+These are not implementation problems. They are specification problems, and they won't be fixed by more `/dev-test` or `/dev-impl` rounds. Stop, go back to `sprints/vN/PRD.md` or `docs/<INITIATIVE>.md`, and re-read the relevant section. If the spec is genuinely ambiguous, run a focused ambiguity pass and produce questions for a human — do not invent answers.
 
 The rule: **third round of "fix this, still broken" means the spec is the problem, not the code.**
 
@@ -242,7 +242,7 @@ The manual `/security-review` checklist remains — as the *escalation path*, no
 
 ### 1.10 Tuning autonomy with `Autonomy:` annotations
 
-Not every task carries the same risk. A doc fix is not a payment-path migration. The `Autonomy:` annotation on a task lets you tell `/dev` how much human checkpointing to do mid-task — instead of using one cadence for everything.
+Not every task carries the same risk. A doc fix is not a payment-path migration. The `Autonomy:` annotation on a task lets you tell `/dev-impl` how much human checkpointing to do mid-task — instead of using one cadence for everything.
 
 Three valid levels:
 
@@ -268,7 +268,7 @@ The annotation sits in the task block alongside `Satisfies:`, `Files:`, etc.:
 
 If you're unsure, default to `checkpoint`. Going one level more cautious costs minutes; going one level less cautious can ship a regression.
 
-**What the tooling does with it.** `reconcile.py` parses `Autonomy:` and surfaces invalid values to stderr (`yolo` is not a level). It does not currently fail on autonomy alone — the annotation is advisory. Once the `/dev` skill ships, it reads this field to decide checkpointing cadence. Even before then, the annotation serves as documentation for human reviewers: a PR landing a `review-only` task with no checkpoint comments in the conversation history is a smell worth surfacing in code review.
+**What the tooling does with it.** `reconcile.py` parses `Autonomy:` and surfaces invalid values to stderr (`yolo` is not a level). It does not currently fail on autonomy alone — the annotation is advisory. `/dev-impl` reads this field to decide checkpointing cadence during implementation. The annotation also serves as documentation for human reviewers: a PR landing a `review-only` task with no checkpoint comments in the conversation history is a smell worth surfacing in code review.
 
 **What the annotation does not replace.** It does not replace test coverage, the security gate, or the test matrix. `Autonomy: direct` does not mean "skip Category D"; it means "given that the test matrix is satisfied, proceed without mid-task pauses." If you're tempted to use `direct` to cut testing, the testing is the problem to solve, not the cadence.
 
@@ -308,7 +308,7 @@ This section is about how to talk to Claude Code specifically in the context of 
 
 ### 2.1 The task kickoff prompt
 
-Start every `/dev` session with the same structure:
+Start every `/dev-test` session with the same structure (the implementation session inherits the same spec by reading the committed tests):
 
 ```
 I'm working on task TNNN in sprints/vN/TASKS.md. Before writing any code:
@@ -329,7 +329,7 @@ This takes Claude Code 2–3 minutes to execute and catches 80% of the "Claude C
 
 ### 2.2 Keeping context clean between sessions
 
-**Each `/dev` session = one task.** Don't batch. Batching is the single fastest way to get Claude Code to shortcut later tasks in favor of earlier ones — the later tasks get shallower work as context fills up.
+**Each `/dev-test` or `/dev-impl` session = one task.** Don't batch. Batching is the single fastest way to get Claude Code to shortcut later tasks in favor of earlier ones — the later tasks get shallower work as context fills up. `dev_session.py` enforces this: a second `/dev-test` or `/dev-impl` kickoff inside the same session is refused.
 
 **Each test-writing session = no implementation context.** Per 1.3, this is non-negotiable.
 
@@ -436,7 +436,7 @@ The method front-loads specification work that used to be deferred. What feels l
 
 **Parallel discovery interviews.** Phase 0 is usually serialized by calendar. Run two or three discovery calls on the same day. Fill the intake during the call, not after. Collapses a week of scheduling into hours.
 
-**Parallel tasks within a sprint.** The "one task per session" rule is about context, not about serializing the team. Three engineers running three `/dev` sessions on three different tasks simultaneously is fine. `/reconcile` in CI keeps them consistent.
+**Parallel tasks within a sprint.** The "one task per session" rule is about context, not about serializing the team. Three engineers running three `/dev-test` or `/dev-impl` sessions on three different tasks simultaneously is fine — each task has its own `Files:` allowlist, and `sprint_gate.py` keeps them from stepping on each other. `/reconcile` in CI keeps them consistent at the requirement-coverage level.
 
 **Parallel Claude Code sessions for independent design-doc sections.** When drafting a design doc for a complex initiative, don't serialize it. Three sessions on auth, data flows, and UI simultaneously; merge outputs. This is the same pattern `/gap` uses, applied earlier.
 
@@ -510,7 +510,7 @@ If the method feels slow after five initiatives, look for these specific problem
 
 ### Never do
 
-- Batch tasks in one `/dev` session
+- Batch tasks in one `/dev-test` or `/dev-impl` session
 - Write tests and implementation in the same session
 - Modify tests to match code
 - Skip the test matrix

--- a/method/AI_Assisted_Development_Method_v3_2_1.md
+++ b/method/AI_Assisted_Development_Method_v3_2_1.md
@@ -134,7 +134,7 @@ Before any work begins, the repository must have the following. If these are mis
 | **docs/failures/ folder** | One entry per significant bug or `/gap` finding. Records root cause, which phase should have caught it, and prevention rule. |
 | **docs/client-facing/ folder** | Client-facing variants of `/gap` reports and delivery walkthroughs. Same data, no internal jargon. Produced at delivery milestones. |
 | **sprints/ directory layout** | `sprints/vN/PRD.md`, `TASKS.md`, `WALKTHROUGH.md`, `RETRO.md`. Sprint has a lockfile indicating closure. |
-| **Skills installed** | `/prd`, `/dev`, `/reconcile`, `/sprint-close`, `/walkthrough`, `/retro`, `/security-review`, `/ui-qa`, `/gap` — or manual checklists if not yet automated. `/reconcile` wired as a CI check. |
+| **Skills installed** | `/prd`, `/dev-test`, `/dev-impl`, `/reconcile`, `/sprint-close`, `/walkthrough`, `/retro`, `/security-review`, `/ui-qa`, `/gap`, `/state-check` — or manual checklists if not yet automated. `/reconcile` wired as a CI check. `/dev-test` and `/dev-impl` run in separate sessions; the split is enforced by `dev_session.py` marker verification so the test-writer and implementation author cannot share a context window. |
 
 ---
 
@@ -173,13 +173,17 @@ The diagram below shows the full cycle. The key structural insight: the method o
 │     Output: sprints/vN/PRD.md + TASKS.md (with Deferred section)         │
 │                                    │                                     │
 │                                    ▼                                     │
-│   /dev — one task at a time                                              │
+│   /dev-test — one task, test-writing session                             │
 │     Step 1: Re-read PRD, announce Satisfies: IDs                         │
 │     Step 2: Ambiguity pass on the task (if still underspecified)         │
 │     Step 2.5: Test matrix A (happy) + B (edge) + C (error)               │
 │                + D (fallthrough) + E (architecture guards)               │
-│     Step 3: Senior-reviewed failing tests committed                      │
+│     Step 3: Senior-reviewed failing tests committed; drops marker        │
+│   /dev-impl — one task, implementation session (new context)             │
 │     Step 4: Implementation — full automated suite in loop                │
+│     Session split enforced by dev_session.py marker verification.        │
+│     Files: allowlist in TASKS.md is load-bearing — sprint_gate.py        │
+│     blocks writes outside the active task's allowlist.                   │
 │                                    │                                     │
 │                                    ▼                                     │
 │   /reconcile — coverage check (mid-sprint or pre-close)                  │
@@ -558,7 +562,7 @@ Small teams often have people wearing multiple hats. This section is descriptive
 
 **Key handoff observations:**
 
-- **PMs own the client-interface parts** (SOW, design-doc framing, client-facing variants) and **do not own the engineering internals** (`/dev`, `/reconcile`, `/security-review`, mutation testing). PMs do not need to run these; they need to know they exist and trust the output.
+- **PMs own the client-interface parts** (SOW, design-doc framing, client-facing variants) and **do not own the engineering internals** (`/dev-test`, `/dev-impl`, `/reconcile`, `/security-review`, mutation testing). PMs do not need to run these; they need to know they exist and trust the output.
 - **Tech leads own the sprint boundaries** (`/prd`, `/sprint-close`) because those are the gates that protect delivery commitments.
 - **Engineers own the tasks and tests** and should push back if `/prd` decomposition gives them tasks without clear `Satisfies:` lines or acceptance criteria.
 - **The whole team owns retros and the failures log.** These are the compounding memory layer; an engineer's insight that doesn't make it into the log is lost.
@@ -571,11 +575,11 @@ If the team is very small (say, three engineers with one acting as tech lead), o
 
 1. **One sprint at a time per initiative stream.** Concurrent sprints on the same initiative produce merge chaos and break `/reconcile`. Parallel initiatives are fine if they touch different code.
 
-2. **One task at a time per `/dev` session.** Batching tasks in one session pollutes context and degrades test discipline. Start a fresh session per task.
+2. **One task at a time per `/dev-test` or `/dev-impl` session.** Batching tasks in one session pollutes context and degrades test discipline. Start a fresh session per task. Enforced by `dev_session.py` marker verification — the hook refuses to start a second task in the same session.
 
 3. **Never skip the test matrix.** Categories D and E are the ones teams skip and the ones that catch real drift. If time pressure prompts you to skip them, that is exactly when they are most needed.
 
-4. **Test writing and implementation must be in separate sessions.** Single-context TDD with an LLM tends to produce implementation-first code disguised as test-first.
+4. **Test writing and implementation must be in separate sessions.** Single-context TDD with an LLM tends to produce implementation-first code disguised as test-first. Enforced by `dev_session.py`: `/dev-test` drops a marker once failing tests are committed; `/dev-impl` refuses to start until that marker exists and runs in a fresh session.
 
 5. **Never accept "it should work" without running it.** If a task finishes without the full automated suite passing, it is not finished.
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -57,7 +57,15 @@ python3 scripts/metrics.py list-events --event-type session --sprint v3
 
 ## Persistence — important caveat
 
-Events written from CI on a PR branch are lost on squash merge (PR branches are ephemeral). The `Logged gate ...` line still appears in the Actions run log — you have visibility, just not aggregation across PRs. A future follow-up adds a commit-back pattern from CI on merged PRs; until then, the highest-value events to capture are the ones engineers log locally: `/gap` runs, `/sprint-close` outcomes, session events, and any gate run on `main` directly.
+`scripts/metrics.py` writes one JSONL line per event to `metrics/events.jsonl` in whatever working tree it runs in. That file is the only persistence layer — there's no database, no remote sink, no aggregation service.
+
+What that means in practice:
+
+- **Local runs persist.** When an engineer runs `python3 scripts/metrics.py log-session ...` locally, the line lands in the working tree's `metrics/events.jsonl`. Commit the file (or commit it as part of `/sprint-close`) to keep the record on `main`.
+- **CI runs on PR branches are ephemeral.** Events written from CI on a feature branch live in that branch's checkout and are lost when the PR squash-merges. The `Logged gate ...` line still appears in the Actions run log — you have run-level visibility, just not aggregation across PRs.
+- **`main`-branch CI runs persist** if your workflow commits the file back. AADM's template workflows leave that wiring as a follow-up; until then, the highest-value events to capture are the ones engineers log locally: `/gap` runs, `/sprint-close` outcomes, session events, and any gate run on `main` directly.
+
+`sprint_close.py`'s `sessions_logged` check reads `metrics/events.jsonl` directly — if the file is missing or empty for the active sprint, the close refuses with a "no session events logged for vN" message. That's the structural backstop for the discipline.
 
 ## Honest caveats
 

--- a/metrics/docs/METRICS.md
+++ b/metrics/docs/METRICS.md
@@ -55,7 +55,7 @@ Gate events are the highest-signal lowest-cost metric you can capture. They take
 
 ### Event type: `session`
 
-Logged at the end of every work session — whether it's a `/dev` task, a test-authoring session in a separate context, a code review, or an ad-hoc investigation. The logging is done by the engineer (or the skill wrapping the engineer's session) via `log-session`, and `sprint_close.py` structurally refuses to lock a sprint with zero logged sessions. That turns session logging from cultural discipline into a hard gate.
+Logged at the end of every work session — whether it's a `/dev-test` or `/dev-impl` task session, a code review, or an ad-hoc investigation. The logging is done by the engineer (or the skill wrapping the engineer's session) via `log-session`, and `sprint_close.py` structurally refuses to lock a sprint with zero logged sessions. That turns session logging from cultural discipline into a hard gate.
 
 | Field | Meaning |
 |---|---|
@@ -69,6 +69,17 @@ Logged at the end of every work session — whether it's a `/dev` task, a test-a
 **Why the `rework` flag.** Rework rate is the single highest-signal indicator that a sprint's scope or spec quality is off. A sprint with 40% rework sessions is telling you something the gate-pass rate is not. We record it today so that when thresholds are calibrated, the data is already there. Until then: record honestly, discuss in retro, don't react to single-sprint numbers.
 
 **What is deliberately NOT in this schema.** No `engineer` field — individual attribution creates bad incentives and doesn't answer any method-calibration question. No token counts — they're coming once cost-per-sprint becomes worth tracking against real engagement data. No `duration` field — durations self-report badly (engineers over-report short sessions and under-report long ones) and aren't worth the noise.
+
+**On-disk shape.** Each event is one JSON object per line in `metrics/events.jsonl`:
+
+```json
+{"ts": "2026-04-21T17:32:14Z", "event_type": "session", "sprint": "v3", "kind": "tests", "task": "T007"}
+{"ts": "2026-04-21T18:45:02Z", "event_type": "session", "sprint": "v3", "kind": "dev", "task": "T007"}
+{"ts": "2026-04-21T20:11:48Z", "event_type": "session", "sprint": "v3", "kind": "dev", "task": "T004", "rework": true}
+{"ts": "2026-04-21T20:14:33Z", "event_type": "gate", "gate": "reconcile", "result": "pass"}
+```
+
+JSONL means: one line per event, append-only, never rewrite history. `sprint_close.py` reads this file directly to confirm the active sprint has at least one session event before allowing the lock.
 
 ---
 
@@ -101,7 +112,7 @@ python3 metrics/scripts/metrics.py log-gate --gate gap --result pass --findings 
 
 ### Logging a work session
 
-At the end of every `/dev` session, test-authoring session, or code review:
+At the end of every `/dev-test`, `/dev-impl`, or code-review session:
 
 ```bash
 # Ordinary dev session on a specific task
@@ -254,4 +265,4 @@ Tools are levers. If the lever isn't moving anything, put it down.
 | Count sessions for a sprint | `metrics.py count-sessions --sprint v3 --json` |
 | List just session events | `metrics.py list-events --event-type session --sprint v3` |
 
-**Default mental model.** Wire `log-gate` into every gate workflow with `if: always()`. Log a session event at the end of every `/dev` / test-authoring / review session — the `sprint_close.py` check will bounce the lock if you don't. Read the raw session counts in retro. Defer threshold-based interpretation (healthy / high / low) until real engagement data calibrates the ranges in a follow-up to [#13](https://github.com/colaberry/ai-assisted-development-method/issues/13).
+**Default mental model.** Wire `log-gate` into every gate workflow with `if: always()`. Log a session event at the end of every `/dev-test`, `/dev-impl`, or code-review session — the `sprint_close.py` check will bounce the lock if you don't. Read the raw session counts in retro. Defer threshold-based interpretation (healthy / high / low) until real engagement data calibrates the ranges in a follow-up to [#13](https://github.com/colaberry/ai-assisted-development-method/issues/13).

--- a/state-check/.claude/skills/state-check.md
+++ b/state-check/.claude/skills/state-check.md
@@ -139,6 +139,15 @@ Ask: what changed in the test files, and why?
 - If the engineer can name a specific test that was wrong and describe why: fine, confirm that a note was added to the commit message or the retro, move on.
 - If the engineer is vague ("just cleanup," "refactoring"): flag this. Suggest they review the diff themselves with fresh eyes before merging. This is the specific failure mode Method Rule 4 guards against.
 
+### State: Gap analysis missing or stale (`gap_analysis_staleness`)
+
+The CLI flagged this as a P1 traceability issue. Two shapes:
+
+- **Missing:** `docs/<INITIATIVE>_GAP_ANALYSIS.md` does not exist for a design doc that has sprints against it. The initiative has never been audited for orphans. Before the next `/sprint-close`, run `/gap` on that initiative — `sprint_close.py` refuses to lock while orphans remain, and without an analysis there's no way to know whether any do.
+- **Stale:** The analysis exists but its mtime is older than the newest sprint `.lock`. Sprints have been closed since the last audit. Orphans added by those sprints haven't been surfaced. Run `/gap` to refresh.
+
+In both cases the next action is `/gap` on the named initiative, not "keep going on the current task." Surface this plainly to the engineer.
+
 ### State: Failures log has many entries but few recent prunes
 
 The CLI flagged this as a P2 memory issue. Don't push hard; just note it:

--- a/state-check/DOCUMENTATION.md
+++ b/state-check/DOCUMENTATION.md
@@ -423,15 +423,15 @@ State-check runs anytime and doesn't modify the repo. It can tell you "the sprin
 
 ### vs. `/gap`
 
-`/gap` is an end-of-initiative audit that runs three parallel agents against the design doc. It's expensive (multi-agent, LLM-driven, minutes to run).
+`/gap` is an initiative-boundary audit that diffs requirement IDs in `docs/<INITIATIVE>.md` against the union of `Satisfies:` citations across every sprint and emits `docs/<INITIATIVE>_GAP_ANALYSIS.md`.
 
-State-check is not `/gap`. It doesn't audit against the design doc; it checks whether state artifacts are present and consistent. If you need to know "did we actually build everything we said in the design doc?", run `/gap`. If you need to know "what should I do in the next hour?", run state-check.
+State-check is not `/gap`. It doesn't audit against the design doc; it checks whether state artifacts are present and consistent. But state-check **does** track the gap analysis as an artifact: the `gap_analysis_staleness` P1 flag fires when `docs/<INITIATIVE>_GAP_ANALYSIS.md` is missing or older than the newest sprint `.lock`. That's how state-check surfaces "the analysis exists but no longer reflects the current sprint state" without re-running `/gap` itself.
 
-**Relationship:** They're complementary. State-check for daily orientation; `/gap` for initiative-level verification.
+**Relationship:** They're complementary. State-check observes that the gap analysis is fresh; `/gap` is the skill that produces and refreshes it. `/sprint-close` reads the analysis to refuse the lock when orphaned requirements remain.
 
 ### vs. CLAUDE.md and the failures log
 
-CLAUDE.md and the failures log are the memory layer. They're consulted at the start of each `/dev` session and during ambiguity passes.
+CLAUDE.md and the failures log are the memory layer. They're consulted at the start of each `/dev-test` session (and inherited into `/dev-impl` via the committed tests) and during ambiguity passes.
 
 State-check reads both but doesn't update them. It flags if CLAUDE.md is bloated or the failures log is unpruned, but it doesn't rewrite either.
 

--- a/state-check/README.md
+++ b/state-check/README.md
@@ -25,7 +25,7 @@ These are a **pair**. The CLI does mechanical state detection; the skill wraps i
 ## What the pair does NOT do
 
 - Does not make judgment calls. "Are we ready to graduate to Stage 2?" is a human decision; the tool surfaces the question, never answers it.
-- Does not replace `/dev`, `/prd`, `/sprint-close`, or other method commands. It tells you which one to run.
+- Does not replace `/dev-test`, `/dev-impl`, `/prd`, `/sprint-close`, `/gap`, or other method commands. It tells you which one to run.
 - Does not modify the repo. Safe to run anytime.
 
 ## Installing
@@ -85,6 +85,8 @@ Exit codes:
 | Every task in active sprint has a `Satisfies:` line | P0 | `/reconcile` will fail without it |
 | Active sprint has PRD.md and TASKS.md | P0 | Sprint infrastructure required |
 | Retro written for active sprint (non-first) | P2 | Per-sprint retro expected |
+| Open `/incident` post-mortems (unresolved or unreviewed) | P1 | Learning-loop flag; closed by `Resolved:` + reviewed post-mortem |
+| Gap analysis missing or stale | P1 | `docs/<INITIATIVE>_GAP_ANALYSIS.md` missing or older than the newest sprint `.lock`; run `/gap` before `/sprint-close` |
 | Tests modified in recent commits | P1 | Possible "tests modified to match code" anti-pattern |
 | Failures log under ~100 entries | P2 | Memory pruning discipline |
 

--- a/tooling/.claude/skills/dev-impl.md
+++ b/tooling/.claude/skills/dev-impl.md
@@ -55,9 +55,18 @@ If `state-check.py` reports P0 flags, resolve them first.
    marker's commit is ahead of HEAD or the wrong tests were committed;
    stop and return to `/dev-test`.
 4. **Implements against the failing tests.** Works only against the
-   files listed in `Files:`. If implementation naturally requires
-   touching a file not on that list, stops and surfaces it — unplanned
-   file creep is the signal of scope drift, not a thing to paper over.
+   files listed in `Files:`. This isn't a soft norm — `sprint_gate.py`
+   runs as a PreToolUse hook and structurally blocks `Edit`/`Write` calls
+   against any path not on the active task's `Files:` allowlist. If
+   implementation naturally requires touching a file not on that list,
+   the hook will refuse the write and the skill must stop and surface
+   the drift to the engineer. Resolution paths: (a) the new file is in
+   scope and the task's `Files:` line was incomplete — close the
+   `/dev-impl` session, edit `Files:` in TASKS.md, restart `/dev-impl`;
+   (b) the new file is *out* of scope and the implementation is creeping
+   — stop, log the realization in the failures-log draft, and either
+   shrink the implementation or split a follow-up task. Silently
+   expanding `Files:` to make the hook pass defeats the gate.
 5. **Runs the full relevant test suite** (unit + integration +
    architecture guards that cover touched modules). Does not declare
    done on a subset. For UI work, exercises the feature in a browser

--- a/tooling/.claude/skills/gap.md
+++ b/tooling/.claude/skills/gap.md
@@ -78,13 +78,31 @@ Refuse to proceed if:
    pass) that *never made it into the design doc* with a stable ID? This
    is the harder failure mode — `gap.py` can only audit what's already a
    §X.Y; it can't audit what was silently dropped between intake and
-   design. For every Section 7.5 category that captured a real
-   requirement, confirm a stable ID exists in the design doc. For every
-   category marked "N/A because X," confirm the reason is reflected in
-   the design doc's Assumptions section. If any are missing, document
-   them in the analysis's "Notes" section as candidates for a design-doc
-   amendment PR. Do not invent IDs in `/gap` — the amendment is a
-   separate review against the design document.
+   design.
+
+   **How to do the check, concretely.** Open the most recent
+   `docs/intake/<CLIENT>-<DATE>.md`. Walk Section 7.5 row by row — the 13
+   categories are functional, non-functional/quality, security/privacy,
+   observability, failure modes, data, operations/runbook,
+   compliance/regulatory, accessibility, internationalization,
+   documentation, training/enablement, decommissioning. For each row:
+   - If the row captured a concrete requirement (not "N/A"), grep
+     `docs/<INITIATIVE>.md` for evidence: a §X.Y heading whose prose
+     covers it, a Dn decision, or a Qn answered question. If you can't
+     find a stable ID covering the substance, that's a missing-ID
+     candidate. List it in the analysis's "Notes" section under a
+     "Section 7.5 → design-doc gaps" subsection, naming the intake row
+     and the substantive requirement that didn't make it across.
+   - If the row was marked "N/A because X", confirm that the same
+     reasoning appears in the design doc's Assumptions section (or an
+     equivalent "out of scope" callout). If the assumption is silent in
+     the design doc, list it in the same "Notes" subsection — silent
+     N/A across the boundary is the same failure mode as silent drop,
+     just at a different layer.
+
+   Do not invent IDs in `/gap` — the amendment is a separate review
+   against the design document. The Notes section is the structured
+   handoff to whoever runs that amendment PR.
 6. **Re-runs the script in `--ci` mode to confirm.**
    ```bash
    python3 tooling/scripts/gap.py docs/<INITIATIVE>.md sprints/ --ci

--- a/tooling/.claude/skills/prd.md
+++ b/tooling/.claude/skills/prd.md
@@ -51,8 +51,9 @@ For Internal Product Mode: if `stage == "exploration"` and `docs/hypothesis.md` 
 ## Interaction with other skills
 
 - `/prd` runs after `/sprint-close` on the previous sprint. Fresh sprints start with an unlocked directory; the hook and state-check expect that state.
-- `/dev-test` and `/dev-impl` run inside a sprint, one task at a time, in separate Claude Code sessions. `/prd` produces the work those skills consume.
+- `/dev-test` and `/dev-impl` run inside a sprint, one task at a time, in separate Claude Code sessions. `/prd` produces the work those skills consume. The `Files:` allowlist on each task is load-bearing: `sprint_gate.py` reads it as a PreToolUse hook and blocks writes outside the active task's allowlist, so vague or missing `Files:` lines translate directly into friction during implementation. Write them carefully.
 - `/sprint-close` reads the PRD and TASKS that `/prd` wrote and enforces coverage before allowing the lock.
+- `/gap` is the complementary initiative-boundary gate. The completeness pass this skill runs (Step 4) works at the *sprint scope* — does every requirement the engineer scoped into vN have a task, a `[DEFERRED]`, or a documented N/A? `/gap` works at the *initiative scope* — does every requirement in `docs/<INITIATIVE>.md` ever make it into some sprint? Both passes are necessary. A requirement can pass `/prd`'s step 4 in every sprint (scope was honest) and still be orphaned at `/gap` (nobody ever scoped it).
 
 ## Deliverables at the end of `/prd`
 

--- a/tooling/.claude/skills/sprint-close.md
+++ b/tooling/.claude/skills/sprint-close.md
@@ -29,6 +29,7 @@ Refuse to proceed if:
 - **The target sprint already has a `.lock` file** — it's already closed. Don't re-run.
 - **Tests are red** — green suite is the baseline. Failing CI is a pre-close blocker.
 - **P0 flags present** — resolve them first. They usually indicate exactly the kind of structural problem `/sprint-close` would trip over anyway.
+- **Initiative-level gap analysis is missing or stale.** `state-check.py` emits a P1 `gap_analysis_staleness` flag when `docs/<INITIATIVE>_GAP_ANALYSIS.md` is missing or older than the newest sprint `.lock`. Run `/gap` first — `sprint_close.py` refuses to lock while orphaned initiative requirements exist, and a stale analysis silently hides new orphans.
 
 Also verify: every non-deferred task in TASKS.md is `[x]` with a `Completed:` date. If any are still `[ ]`, stop and list them.
 
@@ -63,6 +64,7 @@ Also verify: every non-deferred task in TASKS.md is `[x]` with a `Completed:` da
 
 - **RETRO.md still has template markers.** Re-run the retro walk-through. The placeholders exist because no one filled them in; the fix is filling them in, not deleting them.
 - **`reconcile.py --ci` fails with a missing requirement.** Either the requirement needs a task (re-open the sprint briefly, add the task, run `/dev-test` then `/dev-impl` in separate sessions), or it needs a `[DEFERRED]` entry with `Target:` and `Reason:`. Silent drop is not an option.
+- **Orphaned initiative requirement (gap analysis failure).** The sprint reconciles green but the initiative-level `docs/<INITIATIVE>_GAP_ANALYSIS.md` shows a requirement that was never picked up in any sprint PRD. Run `/gap`, decide on each orphan (scope into this sprint, `[DEFERRED]` with `Target:`, or design-doc amendment), re-run `/gap --ci` to exit 0, then re-run `/sprint-close`. This is the initiative-boundary gate; it complements the per-sprint `/reconcile` gate and exists specifically because a requirement can reconcile green in every sprint while never actually being touched.
 - **Symbol-presence `STUB-WARNING:` on a `[x]` task.** The task claims to be done but the files don't contain the symbols the title/acceptance imply. Either finish the implementation or un-mark the task.
 - **`sessions_logged` fails with "no session events logged for vN".** `sprint_close.py` refuses to lock a sprint with zero logged sessions when the `metrics/` module is installed. The fix is honesty: if sessions happened and weren't logged, log them retroactively from memory; if you genuinely never logged any, that's the signal the discipline hasn't landed yet and the retro should call it out. If the repo is on the minimum-viable adoption path (no `metrics/` module), the check passes with a "not installed" note — this refusal mode only fires for teams that opted into metrics logging.
 - **`security_review` / `ui_qa` fails with "SECURITY-REVIEW.md is missing" or "UI-QA.md is missing".** The PRD's scope flag says `Yes` but no artifact is committed. Run `/security-review` or `/ui-qa`; commit the artifact; re-run `/sprint-close`.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -3,23 +3,38 @@
 This bundle contains the minimum tooling to start using the method on a new client repo:
 
 - A working `/reconcile` script (Python, stdlib only)
-- A `sprint_close.py` script that atomically closes a sprint after running `/reconcile` and verifying RETRO + sign-off
-- A GitHub Actions workflow that runs `/reconcile` as a CI merge gate
-- Templates for CLAUDE.md, the failures log, retrospectives, and sprint artifacts
+- A `sprint_close.py` script that atomically closes a sprint after running `/reconcile`, verifying RETRO + sign-off, checking the security/UI-QA artifacts, and confirming session events were logged
+- A `gap.py` script that diffs design-doc requirement IDs against sprint `Satisfies:` citations and writes `docs/<INITIATIVE>_GAP_ANALYSIS.md`
+- A `dev_session.py` script that records `/dev-test`/`/dev-impl` markers so the test-writer and implementation author cannot share a Claude Code session
+- A `sprint_gate.py` PreToolUse hook that blocks writes outside the active sprint and outside the active task's `Files:` allowlist
+- GitHub Actions workflows for `/reconcile` and `/security` as CI merge gates
+- Templates for CLAUDE.md, the failures log, retrospectives, sprint artifacts, the client intake (with the §7.5 elicitation completeness pass), security/UI-QA reviews, and incident post-mortems
 
 ## Contents
 
 ```
 scripts/
 ├── reconcile.py                    # Sprint coverage check
-└── sprint_close.py                 # Atomic sprint closure (writes .lock)
+├── sprint_close.py                 # Atomic sprint closure (writes .lock)
+├── gap.py                          # Initiative-boundary orphan/conflict detection
+└── dev_session.py                  # /dev-test → /dev-impl marker verification
+hooks/
+└── sprint_gate.py                  # PreToolUse hook: sprint-lock + Files: allowlist
 .github/workflows/
-└── reconcile.yml                   # CI integration
+├── reconcile.yml                   # CI integration for /reconcile
+└── security.yml                    # CI integration for Semgrep
 templates/
 ├── CLAUDE.md                       # Per-client persistent context
+├── client-intake-TEMPLATE.md       # Phase 0 intake (incl. §7.5 completeness pass)
+├── claude-settings-hooks-TEMPLATE.json  # Hooks block to merge into .claude/settings.json
 ├── failures-log-README.md          # Folder-level README for docs/failures/
 ├── failures-log-TEMPLATE.md        # Single entry template
+├── incident-TEMPLATE.md            # Post-mortem template
 ├── retro-TEMPLATE.md               # Per-sprint retrospective
+├── security-review-TEMPLATE.md     # Manual security review artifact
+├── security-suppressions-TEMPLATE.md
+├── ui-qa-TEMPLATE.md               # UI quality artifact
+├── code-review-AI-CHECKLIST.md     # AI-assisted PR review checklist
 ├── sprint-PRD-TEMPLATE.md          # Sprint planning document
 └── sprint-TASKS-TEMPLATE.md        # Task list in the format /reconcile parses
 ```
@@ -117,7 +132,10 @@ When you're ready to close a sprint, this is the one entry point. It:
 2. Runs `reconcile.py --ci` against the sprint. Pass `--strict-symbols` to also fail on empty stubs.
 3. Verifies `RETRO.md` is no longer the template (no `<placeholder>`, no literal `vN`, no literal `YYYY-MM-DD`, and the "What went well" / "What went poorly" sections contain real content).
 4. Verifies sign-off — either an existing `SIGNOFF.md` containing `Reviewer: <name>` and `Date: YYYY-MM-DD`, or `--reviewer NAME` to create one.
-5. Writes `sprints/vN/.lock` only if every check above passed. The `.lock` file records `locked_at`, `reviewer`, and `reconcile_status` — downstream tooling (the planned PreToolUse hook) reads this to know the sprint is closed.
+5. **Verifies the security and UI-QA artifacts** named by the PRD's scope flags. If `/security-review required: Yes`, `sprints/vN/SECURITY-REVIEW.md` must exist with a non-blocked `Decision:` line; same for `/ui-qa required: Yes` and `UI-QA.md`. Either missing or `Decision: blocked` refuses the lock.
+6. **Verifies session events were logged** for the sprint when the `metrics/` module is installed. `sprint_close.py` reads `metrics/events.jsonl` and refuses to lock with "no session events logged for vN" if no `session` events name the active sprint. Repos on the minimum-viable adoption path (no `metrics/` module) get a "not installed" pass on this check — the refusal only fires for teams that opted into metrics.
+7. **Verifies the initiative-level gap analysis is current** when `docs/<INITIATIVE>_GAP_ANALYSIS.md` is present. Orphaned requirements in the analysis refuse the lock; run `/gap` to clear them or document the resolution before retrying.
+8. Writes `sprints/vN/.lock` only if every check above passed. The `.lock` file records `locked_at`, `reviewer`, and `reconcile_status` — `sprint_gate.py` reads this on every PreToolUse to decide whether writes into vN+1 are allowed.
 
 ```bash
 # Close v3 with the reviewer recorded inline
@@ -166,7 +184,7 @@ chmod +x .claude/hooks/sprint_gate.py
 
 Intentionally out of scope for day-one tooling:
 
-- **`/walkthrough`, `/gap`, `/security-review`, `/ui-qa` automation.** These are higher-leverage to build later once the team has used the basic pieces and knows what shape each one needs. Start with manual checklists invoked as Claude Code slash commands; promote to scripts when the manual process stabilizes. (Sprint close itself is now scripted via `sprint_close.py`; security is gated structurally via `security.yml`.)
+- **`/walkthrough` automation.** Still a manual checklist invoked as a Claude Code slash command; promote to a script when the manual process stabilizes. (`/gap` is scripted via `gap.py`; `/sprint-close` via `sprint_close.py`; `/security-review` and `/ui-qa` ship as templates with `sprint_close.py` enforcement on the artifacts.)
 - **Mutation testing setup.** Language-specific; set up with Stryker / mutmut / PIT when you pick the critical modules.
 - **`docs/patterns/` folder for positives.** Per v3.2 guidance, do not pre-emptively add this until you have a clear signal the team needs it.
 

--- a/tooling/templates/CLAUDE.md
+++ b/tooling/templates/CLAUDE.md
@@ -162,11 +162,11 @@ when you have real entries.>
 
 These come from the AI-Assisted Development Method (AADM) and apply to every session:
 
-1. **Never start work on sprint vN+1 until sprint vN has been locked via `/sprint-close`.**
-2. **Every task has a `Satisfies:` line citing the design-doc requirement IDs it closes.**
-3. **Silent descoping is an anti-pattern.** Dropping a requirement requires an explicit `[DEFERRED]` entry naming the target sprint. Likewise, silent scope expansion in implementation phases is the inverse anti-pattern: when scope feels wrong, kick it back to a proposal phase rather than expanding silently.
-4. **Test writing and implementation are in separate Claude Code sessions.** Use `/dev-test` to write the failing test matrix and commit it, then a **new session** with `/dev-impl` to implement. `dev_session.py check-impl-ready` refuses the implementation session until the `/dev-test` marker is on disk and the recorded test commit is verifiable.
-5. **One task at a time per `/dev-test` or `/dev-impl` session.**
+1. **Never start work on sprint vN+1 until sprint vN has been locked via `/sprint-close`.** Enforced by `sprint_gate.py` (PreToolUse hook) — writes into `sprints/vN+1/` are refused while `sprints/vN/.lock` is missing.
+2. **Every task has a `Satisfies:` line citing the design-doc requirement IDs it closes.** Enforced by `reconcile.py` in CI — uncovered requirement IDs fail the build.
+3. **Silent descoping is an anti-pattern.** Dropping a requirement requires an explicit `[DEFERRED]` entry naming the target sprint and reason; `sprint_close.py` refuses to lock when a requirement is dropped without one. Likewise, silent scope expansion in implementation phases is the inverse anti-pattern: `sprint_gate.py` blocks `Edit`/`Write` calls on files outside the active task's `Files:` allowlist, so when scope feels wrong, kick it back to a proposal phase rather than expanding silently.
+4. **Test writing and implementation are in separate Claude Code sessions.** Use `/dev-test` to write the failing test matrix and commit it, then a **new session** with `/dev-impl` to implement. `dev_session.py check-impl-ready` refuses the implementation session until the `/dev-test` marker is on disk and the recorded test commit is verifiable. Trying to implement in the same session that wrote tests is refused, not merely discouraged.
+5. **One task at a time per `/dev-test` or `/dev-impl` session.** `dev_session.py` records the active task per session; a second `/dev-test` or `/dev-impl` kickoff in the same session is refused.
 6. **`/sprint-close` runs `/reconcile`, `/security-review` (if in scope), `/ui-qa` (if in scope), `/walkthrough`, and `/retro` before locking.**
 7. **Client-facing artifacts are projections of internal artifacts. They never contradict `/reconcile` or `/gap` output.**
 8. **Requirement IDs are stable. Never renamed or renumbered.**

--- a/tooling/templates/sprint-PRD-TEMPLATE.md
+++ b/tooling/templates/sprint-PRD-TEMPLATE.md
@@ -55,6 +55,8 @@ Explicitly listed here so `/reconcile` can distinguish "in scope but not done" f
 - **`/security-review` required:** Yes / No
 - **`/ui-qa` required:** Yes / No
 
+> Setting either flag to `Yes` is structurally enforced — `sprint_close.py` reads these lines and refuses to lock the sprint unless `sprints/vN/SECURITY-REVIEW.md` (and/or `sprints/vN/UI-QA.md`) exists with a signed `Decision:` line that is not `blocked`. Mark `Yes` deliberately: it commits the sprint to running the corresponding skill. Mark `No` only when scope genuinely doesn't touch the surface; if the answer is "probably not but we should check," the answer is `Yes`.
+
 ---
 
 ## Known risks

--- a/tooling/templates/sprint-TASKS-TEMPLATE.md
+++ b/tooling/templates/sprint-TASKS-TEMPLATE.md
@@ -12,13 +12,15 @@ The `/reconcile` script parses this file. Format must be preserved:
 - The `Satisfies:` subline lists requirement IDs separated by commas or spaces.
 - The `Files:` subline lists paths the task touches, comma-separated.
 
-**Optional `Autonomy:` annotation.** Each task may declare how much human checkpointing `/dev` should do while executing it. Valid values:
+> **`Files:` is load-bearing, not advisory.** `sprint_gate.py` runs as a PreToolUse hook in `/dev-impl` and structurally blocks `Edit`/`Write` calls against any path not on the active task's `Files:` allowlist. A vague or incomplete `Files:` line translates directly into refused writes during implementation. List every file the task is expected to touch; if a refactor reveals a file you missed, close the `/dev-impl` session, amend `Files:` here, and restart — that's the seam where scope expansion becomes visible. Empty `Files:` is acceptable only for research-style tasks that produce no code.
+
+**Optional `Autonomy:` annotation.** Each task may declare how much human checkpointing `/dev-impl` should do while executing it. Valid values:
 
 - `direct` — Claude proceeds task end-to-end; reviewer sees the diff. Use for low-risk, well-tested, easily reversible work (refactors with strong test coverage, doc updates, isolated utility additions).
 - `checkpoint` — Claude pauses at intermediate milestones for confirmation. The default. Use for ordinary feature work.
 - `review-only` — every step requires explicit human go-ahead before continuing. Use for high-risk changes: security boundaries, payment paths, schema migrations, anything touching production data.
 
-Tie the level to actual risk and test coverage, not to how much you trust the engineer or the model. A task with thin Category D fallthrough coverage on production-touching code is `review-only` even if the diff looks small. `reconcile.py` parses `Autonomy:` and warns on unknown values; `/dev` (when scripted) reads it to tune confirmation cadence.
+Tie the level to actual risk and test coverage, not to how much you trust the engineer or the model. A task with thin Category D fallthrough coverage on production-touching code is `review-only` even if the diff looks small. `reconcile.py` parses `Autonomy:` and warns on unknown values; `/dev-impl` reads it to tune confirmation cadence during implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Full-project documentation sweep after a parallel 4-agent audit of README, START-HERE, handbook, method, skills, templates, and module READMEs.
- Brings every document into alignment with what the tooling actually enforces today (sprint_gate.py, dev_session.py, sprint_close.py, gap.py, reconcile.py, state-check.py) — no aspirational language, no new rules.
- Every reference to the old `/dev` skill is updated to name `/dev-test` or `/dev-impl` based on the actual risk surface; every structural enforcement point is now cited where the corresponding rule lives.

## What changed, by surface

- **README.md, START-HERE.md** — redrew flow diagrams to include `/dev-test`, `/dev-impl`, `/gap`, and `sprint_gate.py` as nodes; rewrote "what this solves" with current failure modes; refreshed tooling tables and bundle layout; pruned stale "doesn't include yet" to match what shipped in #25, #26, #27, #28, and #45.
- **Method document** — Skills installed row names `/dev-test`, `/dev-impl`, `/state-check` and cites `dev_session.py`; process flow splits the single `/dev` step into two sessions; rules 2 and 4 cite `dev_session.py` as the enforcement surface.
- **Developer Handbook** — every `/dev` reference split into `/dev-test` or `/dev-impl`; §1.3 spells out the marker mechanic; §1.10 attributes autonomy-cadence reading to `/dev-impl`; parallel-tasks note cites `sprint_gate.py`'s per-task `Files:` allowlist.
- **Skills** — `sprint-close.md` adds the `/gap`-orphans refusal mode and the gap-analysis-staleness precondition; `prd.md` clarifies the boundary between its step-4 completeness pass (sprint scope) and `/gap`'s step-5 upstream pass (intake → design doc); `gap.md` step 5 now gives concrete HOW-TO instructions for the Section 7.5 cross-check; `dev-impl.md` scope-drift wording aligns with `sprint_gate.py`'s structural block.
- **Templates** — `sprint-TASKS-TEMPLATE` callout that `Files:` is load-bearing; `sprint-PRD-TEMPLATE` callout that setting security/ui-qa scope to Yes commits the sprint to the corresponding skill; `CLAUDE.md` rules 1–5 now name the enforcement surface for each rule.
- **state-check** — README and DOCUMENTATION.md describe the `gap_analysis_staleness` P1 flag; state-check skill adds a "Handling specific states" entry for it.
- **metrics** — README explicitly describes `events.jsonl` as the only persistence layer and names the `sprint_close.py sessions_logged` backstop; `METRICS.md` adds a concrete on-disk JSONL example and updates prose from `/dev` to `/dev-test`/`/dev-impl`.
- **tooling/README** — Contents block now lists `gap.py`, `dev_session.py`, `sprint_gate.py`, `security.yml`, and the full current template set; `sprint_close.py` section documents every refusal mode; "doesn't include" pruned to reflect what's actually been shipped.

## Test plan

- [x] `python3 state-check/tests/test_state_check.py` — 44 pass
- [x] `python3 -m unittest discover -s tooling/tests` — 177 pass
- [x] `python3 -m unittest discover -s metrics/tests` — 32 pass
- [ ] Reviewer skims the README and START-HERE flow diagrams and confirms they read cleanly end-to-end.
- [ ] Reviewer skims the skills (sprint-close, prd, gap, dev-impl) and confirms the cross-references land without dangling pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
