### PR TITLE
docs(control-tower): record Option B snapshot policy

### DIFF
--- a/internal-mode/engagements/aadm-control-tower/README.md
+++ b/internal-mode/engagements/aadm-control-tower/README.md
@@ -1,0 +1,40 @@
+# AADM Control Tower — dogfood engagement artifacts
+
+This directory holds reference artifacts for the **AADM Control Tower** initiative, an internal webapp that Colaberry builds under AADM Internal Product Mode (see `../../Internal_Product_Mode.md`).
+
+## What is here
+
+| File | What it is |
+|---|---|
+| `intake.md` | Phase-0 intake produced on 2026-04-23. Captures the problem, users, constraints, and graduation signals for the initiative. |
+| `design-stage-0.md` | Stage 0 design doc (localhost-only scope). Stable IDs §X.Y, D1–D7, Q12–Q17. Sprint v1 scope handoff in §13. |
+
+## Canonical-source policy
+
+**Today (before the Control Tower repo exists):** the files in this directory are the **canonical source of truth** for the initiative. All edits, reviews, and sign-offs happen here.
+
+**After the Control Tower repo is bootstrapped** (Sprint v1 Task 1, per design doc §13): the files in this directory become **frozen snapshots**. The canonical source of truth moves to the Control Tower repo's `docs/` folder. At that point:
+
+1. Sprint v1 Task 1 copies `intake.md` and `design-stage-0.md` into the new Control Tower repo.
+2. Sprint v1 Task 1 also adds a "SNAPSHOT" banner to the top of each file in **this** directory, pointing to the canonical location.
+3. From that point forward, edits happen only in the Control Tower repo. The snapshots in this directory are not updated unless explicitly re-synced (rare — only when a teaching-quality reason exists).
+
+This is **Option B** of the three choices discussed on 2026-04-23. Option A (move entirely) and Option C (keep both synced) were rejected.
+
+### Why Option B
+
+- **AADM repo keeps teaching value.** Anyone reading the AADM method can see a real intake and real design doc produced by applying the method. Without a snapshot here, the AADM repo becomes method-only and loses its best example.
+- **One source of truth for live work.** The Control Tower repo owns the live version. No risk of two diverging forks.
+- **No sync-maintenance cost.** Snapshots are frozen, not kept in lockstep. The "SNAPSHOT" banner makes the frozen state obvious to readers.
+
+### The snapshot banner (format, for reference)
+
+When Sprint v1 Task 1 adds the banner, it looks like this at the top of each file in this directory:
+
+```markdown
+> **📸 SNAPSHOT — <date>.** This file is a frozen reference copy. The canonical, live version lives in the Control Tower repo at `docs/<filename>`. Edits made here will not propagate. To change the live document, edit it in the Control Tower repo.
+```
+
+## Convention for future dogfood engagements
+
+This directory establishes the pattern `internal-mode/engagements/<initiative>/` for all future Colaberry internal-product-mode engagements. Each initiative gets its own subdirectory, its own `README.md`, and the same canonical-source-policy lifecycle (canonical here until the initiative's own repo exists, then snapshots).

--- a/internal-mode/engagements/aadm-control-tower/design-stage-0.md
+++ b/internal-mode/engagements/aadm-control-tower/design-stage-0.md
@@ -382,7 +382,7 @@ Proposed sprint v1 scope (mirrors intake §14 with design-doc IDs attached):
 
 | # | Task | Satisfies |
 |---|---|---|
-| 1 | Repo bootstrap — monorepo scaffold (`backend/`, `frontend/`, `docker-compose.yml`, `.env.example`, AADM `.claude/` skills). | §3.1, §3.3 |
+| 1 | Repo bootstrap — new git repo at `colaberry/aadm-control-tower` (GitHub); monorepo scaffold (`backend/`, `frontend/`, `docker-compose.yml`, `.env.example`, AADM `.claude/` skills); copy `intake.md` and `design-stage-0.md` into the new repo's `docs/`; then add a "SNAPSHOT" banner to the AADM-repo copies pointing to the canonical location (per `internal-mode/engagements/aadm-control-tower/README.md`). | §3.1, §3.3 |
 | 2 | `RepoSource` abstraction + `LocalFilesystemRepoSource` impl + Category E guard. | §4.1, D1 |
 | 3 | `AuthProvider` abstraction + `DevBypassAuth` impl + Category E guard. | §4.2, D1 |
 | 4 | `SecretSource` abstraction + `EnvVarSecretSource` impl + Category E guard. | §4.3, D1 |


### PR DESCRIPTION
## Summary

Record the **Option B snapshot policy** for Control Tower dogfood artifacts. Decision made 2026-04-23: the files in `internal-mode/engagements/aadm-control-tower/` are canonical until the Control Tower repo is bootstrapped (Sprint v1 Task 1). After that, they become frozen snapshots and the canonical source moves to the Control Tower repo's `docs/` folder.

## What's in this PR

- **New file:** `internal-mode/engagements/aadm-control-tower/README.md` — explains what is in this directory, the canonical-source policy, and why Option B was chosen over A (move entirely) or C (keep both synced). Also establishes `internal-mode/engagements/<initiative>/` as the convention for future dogfood engagements.
- **One-line edit** to `design-stage-0.md` §13 Sprint v1 Task 1 — adds the "copy into new repo + add SNAPSHOT banner to AADM copies" step to Task 1 scope. This way the instruction is already in the design doc when `/prd` breaks it into sprint tasks.

## Why this matters

Without recording the decision now, it gets lost by the time Sprint v1 Task 1 runs (maybe a week from now). Writing it into the README and into Task 1's scope is the cheap way to make sure the "snapshot banner" step actually happens.

## Test plan

- [ ] Render the new README on github.com; confirm tables and code blocks look right.
- [ ] Confirm design doc Task 1 now mentions the new-repo creation, file copy, and SNAPSHOT banner steps.
- [ ] Self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
